### PR TITLE
feat(eat): 引入动态资源路径配置

### DIFF
--- a/eat/config.json
+++ b/eat/config.json
@@ -1,4 +1,11 @@
 {
+  "meta": {
+    "repo_owner": "ClearLuv",
+    "repo_name": "TeleBox_Plugins",
+    "branch": "beta",
+    "base_url_template": "https://github.com/${repo_owner}/${repo_name}/raw/${branch}"
+  }, 
+ "resources": {
    "ada": {
     "name": "给爷死",
     "url": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/eatada.png",
@@ -15,103 +22,103 @@
   },
   "bc": {
     "name": "鞭笞",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eatbc.png?raw=true",
+    "url": "eat/eatbc.png",
     "me": {
       "x": 331,
       "y": 76,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskbc1.png?raw=true"
+      "mask": "eat/maskbc1.png"
     },
     "you": {
       "x": 23,
       "y": 292,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskbc2.png?raw=true"
+      "mask": "eat/maskbc2.png"
     }
   }, 
   "dd": {
     "name": "逗逗你呀~",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eatdd.png?raw=true",
+    "url": "eat/eatdd.png",
     "you": {
       "x": 175,
       "y": 62,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskdd.png?raw=true"
+      "mask": "eat/maskdd.png"
     }
   },
   "dl": {
     "name": "大佬~可靠",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eatdl.png?raw=true",
+    "url": "eat/eatdl.png",
     "me": {
       "x": 350,
       "y": 197,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskdl1.png?raw=true"
+      "mask": "eat/maskdl1.png"
     },
     "you": {
       "x": 91,
       "y": 16,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskdl2.png?raw=true"
+      "mask": "eat/maskdl2.png"
     }
   },  
   "fk": {
     "name": "国际友好手势",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eatfk.png?raw=true",
+    "url": "eat/eatfk.png",
     "me": {
       "x": 184,
       "y": 143,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskfk.png?raw=true"
+      "mask": "eat/maskfk.png"
     }
   },
   "fl": {
     "name": "翻脸",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eatfl.png?raw=true",
+    "url": "eat/eatfl.png",
     "you": {
       "x": 7,
       "y": 19,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskfl.png?raw=true"
+      "mask": "eat/maskfl.png"
     }
   },     
   "ko": {
     "name": "升龙拳",
-    "url": "https://github.com/FoKit/PagerMaid_Plugins/blob/modify/eat/eatko.png?raw=true",
+    "url": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/eatko.png",
     "you": {
       "x": 170,
       "y": 95,
-      "mask": "https://github.com/FoKit/PagerMaid_Plugins/blob/modify/eat/maskko.png?raw=true"
+      "mask": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/maskko.png"
     }
   },
   "kz": {
     "name": "看来真得控制你了",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eatkz.png?raw=true",
+    "url": "eat/eatkz.png",
     "you": {
       "x": 1,
       "y": 202,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskkz.png?raw=true"
+      "mask": "eat/maskkz.png"
     }
   },  
   "ld": {
     "name": "我没意见",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eatld.png?raw=true",
+    "url": "eat/eatld.png",
     "you": {
       "x": 157,
       "y": 0,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskld.png?raw=true"
+      "mask": "eat/maskld.png"
     }
   },
   "ri": {
     "name": "日一下",
-    "url": "https://github.com/FoKit/PagerMaid_Plugins/blob/modify/eat/eatri.png?raw=true",
+    "url": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/eatri.png",
     "you": {
       "x": 64,
       "y": 87,
-      "mask": "https://github.com/FoKit/PagerMaid_Plugins/blob/modify/eat/maskri.png?raw=true"
+      "mask": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/maskri.png"
     }
   },
   "sj": {
     "name": "我会一直视奸你",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eatsj.png?raw=true",
+    "url": "eat/eatsj.png",
     "me": {
       "x": 118,
       "y": 42,
       "brightness": 0.6,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/masksj.png?raw=true"
+      "mask": "eat/masksj.png"
     }
   },          
   "tc": {
@@ -130,47 +137,48 @@
   },
   "tlg": {
     "name": "偷撸狗",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eattlg.png?raw=true",
+    "url": "eat/eattlg.png",
     "you": {
       "x": 16,
       "y": 280,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/masktlg.png?raw=true"
+      "mask": "eat/masktlg.png"
     }
   },
   "wyy": {
     "name": "网抑云时间",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eatwyy.png?raw=true",
+    "url": "eat/eatwyy.png",
     "you": {
       "x": 135,
       "y": 160,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskwyy.png?raw=true"
+      "mask": "eat/maskwyy.png"
     }
   },  
   "wyz": {
     "name": "我有罪",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eatwyz.png?raw=true",
+    "url": "eat/eatwyz.png",
     "you": {
       "x": 153,
       "y": 0,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskwyz.png?raw=true"
+      "mask": "eat/maskwyz.png"
     }
   },
   "xyy": {
     "name": "性压抑了",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eatxyy.png?raw=true",
+    "url": "eat/eatxyy.png",
     "you": {
       "x": 146,
       "y": 0,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskxyy.png?raw=true"
+      "mask": "eat/maskxyy.png"
     }
   },  
   "yuyu": {
     "name": "我有郁郁症",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eatyuyu.png?raw=true",
+    "url": "eat/eatyuyu.png",
     "you": {
       "x": 55,
       "y": 52,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskyuyu.png?raw=true"
+      "mask": "eat/maskyuyu.png"
     }
   }
+ } 
 }


### PR DESCRIPTION
> 更新 config.json 结构:

配置文件被拆分为 meta（元数据）和 resources（资源列表）两个部分。

meta 块中定义了仓库所有者、仓库名、当前分支以及URL模板，作为动态生成资源路径的依据。

> 增强插件逻辑 (eat.ts):

新增 loadConfigResource 逻辑，用于在启动时解析 meta 配置并动态构建资源的基础URL (resourceBaseUrl)。

添加了 resolveResourceUrl 辅助函数，用于将资源列表中的相对路径安全地转换为完整的绝对URL。

修改了所有直接使用资源路径的地方（如 compositeWithEntryConfig 和 iconMaskedFor），强制它们通过 resolveResourceUrl 获取最终路径，以确保配置生效。