### PR TITLE
feat(eat): 引入动态资源路径配置

### DIFF
--- a/.github/workflows/update-eat-config.yml
+++ b/.github/workflows/update-eat-config.yml
@@ -1,0 +1,62 @@
+
+name: 'Update Config for Main Branch'
+on:
+  push:
+    branches:
+      - main
+jobs:
+  update-config-on-main:
+    # 跳过由机器人自己产生的提交，防止无限循环
+    if: "contains(github.event.head_commit.message, '[ci skip]') == false && contains(github.event.head_commit.message, 'ci:') == false"
+
+    runs-on: ubuntu-latest
+
+    steps:
+      # 步骤 1: 检出（checkout）你的代码
+      # 使用 Personal Access Token (PAT) 以确保我们有权限将修改推回代码库
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT }} # 请确保您已在仓库的 Secrets 中配置了名为 PAT 的访问令牌
+
+      # 步骤 2: 修改 eat/config.json 文件
+      # 使用 jq 工具，它可以方便地处理 JSON 文件
+      - name: 'Update repo_owner and branch in eat/config.json'
+        run: |
+          # 定义文件路径
+          CONFIG_FILE="eat/config.json"
+
+          # 检查文件是否存在
+          if [ ! -f "$CONFIG_FILE" ]; then
+            echo "Error: $CONFIG_FILE not found!"
+            exit 1
+          fi
+          
+          # 使用 jq 将 .meta.repo_owner 修改为 "TeleBoxDev"，并将 .meta.branch 修改为 "main"
+          # 这个命令会读取原文件，进行两次修改，然后输出到临时文件，最后替换原文件
+          jq '.meta.repo_owner = "TeleBoxDev" | .meta.branch = "main"' "$CONFIG_FILE" > temp.json && mv temp.json "$CONFIG_FILE"
+          
+          echo "$CONFIG_FILE updated successfully."
+
+      # 步骤 3: 提交并推送修改
+      - name: 'Commit and push changes'
+        run: |
+          # 配置 git 用户信息，表明这是由机器人操作的
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          
+          # 检查是否有文件变动。如果没有变动，则不执行任何操作。
+          if git diff --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          
+          # 将修改后的文件添加到暂存区
+          git add eat/config.json
+          
+          # 创建一个新的提交
+          git commit -m "ci: Auto-update config for main branch [ci skip]"
+          
+          # 将提交推送到 main 分支
+          git push
+          echo "Changes have been committed and pushed to the main branch."

--- a/eat/config.json
+++ b/eat/config.json
@@ -1,4 +1,11 @@
 {
+  "meta": {
+    "repo_owner": "ClearLuv",
+    "repo_name": "TeleBox_Plugins",
+    "branch": "beta",
+    "base_url_template": "https://github.com/${repo_owner}/${repo_name}/raw/${branch}"
+  }, 
+ "resources": {
    "ada": {
     "name": "给爷死",
     "url": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/eatada.png",
@@ -15,103 +22,103 @@
   },
   "bc": {
     "name": "鞭笞",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eatbc.png?raw=true",
+    "url": "eat/eatbc.png",
     "me": {
       "x": 331,
       "y": 76,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskbc1.png?raw=true"
+      "mask": "eat/maskbc1.png"
     },
     "you": {
       "x": 23,
       "y": 292,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskbc2.png?raw=true"
+      "mask": "eat/maskbc2.png"
     }
   }, 
   "dd": {
     "name": "逗逗你呀~",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eatdd.png?raw=true",
+    "url": "eat/eatdd.png",
     "you": {
       "x": 175,
       "y": 62,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskdd.png?raw=true"
+      "mask": "eat/maskdd.png"
     }
   },
   "dl": {
     "name": "大佬~可靠",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eatdl.png?raw=true",
+    "url": "eat/eatdl.png",
     "me": {
       "x": 350,
       "y": 197,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskdl1.png?raw=true"
+      "mask": "eat/maskdl1.png"
     },
     "you": {
       "x": 91,
       "y": 16,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskdl2.png?raw=true"
+      "mask": "eat/maskdl2.png"
     }
   },  
   "fk": {
     "name": "国际友好手势",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eatfk.png?raw=true",
+    "url": "eat/eatfk.png",
     "me": {
       "x": 184,
       "y": 143,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskfk.png?raw=true"
+      "mask": "eat/maskfk.png"
     }
   },
   "fl": {
     "name": "翻脸",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eatfl.png?raw=true",
+    "url": "eat/eatfl.png",
     "you": {
       "x": 7,
       "y": 19,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskfl.png?raw=true"
+      "mask": "eat/maskfl.png"
     }
   },     
   "ko": {
     "name": "升龙拳",
-    "url": "https://github.com/FoKit/PagerMaid_Plugins/blob/modify/eat/eatko.png?raw=true",
+    "url": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/eatko.png",
     "you": {
       "x": 170,
       "y": 95,
-      "mask": "https://github.com/FoKit/PagerMaid_Plugins/blob/modify/eat/maskko.png?raw=true"
+      "mask": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/maskko.png"
     }
   },
   "kz": {
     "name": "看来真得控制你了",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eatkz.png?raw=true",
+    "url": "eat/eatkz.png",
     "you": {
       "x": 1,
       "y": 202,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskkz.png?raw=true"
+      "mask": "eat/maskkz.png"
     }
   },  
   "ld": {
     "name": "我没意见",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eatld.png?raw=true",
+    "url": "eat/eatld.png",
     "you": {
       "x": 157,
       "y": 0,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskld.png?raw=true"
+      "mask": "eat/maskld.png"
     }
   },
   "ri": {
     "name": "日一下",
-    "url": "https://github.com/FoKit/PagerMaid_Plugins/blob/modify/eat/eatri.png?raw=true",
+    "url": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/eatri.png",
     "you": {
       "x": 64,
       "y": 87,
-      "mask": "https://github.com/FoKit/PagerMaid_Plugins/blob/modify/eat/maskri.png?raw=true"
+      "mask": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/maskri.png"
     }
   },
   "sj": {
     "name": "我会一直视奸你",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eatsj.png?raw=true",
+    "url": "eat/eatsj.png",
     "me": {
       "x": 118,
       "y": 42,
       "brightness": 0.6,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/masksj.png?raw=true"
+      "mask": "eat/masksj.png"
     }
   },          
   "tc": {
@@ -130,47 +137,48 @@
   },
   "tlg": {
     "name": "偷撸狗",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eattlg.png?raw=true",
+    "url": "eat/eattlg.png",
     "you": {
       "x": 16,
       "y": 280,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/masktlg.png?raw=true"
+      "mask": "eat/masktlg.png"
     }
   },
   "wyy": {
     "name": "网抑云时间",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eatwyy.png?raw=true",
+    "url": "eat/eatwyy.png",
     "you": {
       "x": 135,
       "y": 160,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskwyy.png?raw=true"
+      "mask": "eat/maskwyy.png"
     }
   },  
   "wyz": {
     "name": "我有罪",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eatwyz.png?raw=true",
+    "url": "eat/eatwyz.png",
     "you": {
       "x": 153,
       "y": 0,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskwyz.png?raw=true"
+      "mask": "eat/maskwyz.png"
     }
   },
   "xyy": {
     "name": "性压抑了",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eatxyy.png?raw=true",
+    "url": "eat/eatxyy.png",
     "you": {
       "x": 146,
       "y": 0,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskxyy.png?raw=true"
+      "mask": "eat/maskxyy.png"
     }
   },  
   "yuyu": {
     "name": "我有郁郁症",
-    "url": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/eatyuyu.png?raw=true",
+    "url": "eat/eatyuyu.png",
     "you": {
       "x": 55,
       "y": 52,
-      "mask": "https://github.com/TeleBoxDev/TeleBox_Plugins/blob/main/eat/maskyuyu.png?raw=true"
+      "mask": "eat/maskyuyu.png"
     }
   }
+ } 
 }

--- a/eat/config.json
+++ b/eat/config.json
@@ -1,184 +1,184 @@
 {
   "meta": {
-    "repo_owner": "ClearLuv",
+    "repo_owner": "TeleBoxDev",
     "repo_name": "TeleBox_Plugins",
-    "branch": "beta",
+    "branch": "main",
     "base_url_template": "https://github.com/${repo_owner}/${repo_name}/raw/${branch}"
-  }, 
- "resources": {
-   "ada": {
-    "name": "给爷死",
-    "url": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/eatada.png",
-    "me": {
-      "x": 283,
-      "y": 146,
-      "mask": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/maskada.png"
+  },
+  "resources": {
+    "ada": {
+      "name": "给爷死",
+      "url": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/eatada.png",
+      "me": {
+        "x": 283,
+        "y": 146,
+        "mask": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/maskada.png"
+      },
+      "you": {
+        "x": 223,
+        "y": 314,
+        "mask": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/maskada.png"
+      }
     },
-    "you": {
-      "x": 223,
-      "y": 314,
-      "mask": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/maskada.png"
-    }
-  },
-  "bc": {
-    "name": "鞭笞",
-    "url": "eat/eatbc.png",
-    "me": {
-      "x": 331,
-      "y": 76,
-      "mask": "eat/maskbc1.png"
+    "bc": {
+      "name": "鞭笞",
+      "url": "eat/eatbc.png",
+      "me": {
+        "x": 331,
+        "y": 76,
+        "mask": "eat/maskbc1.png"
+      },
+      "you": {
+        "x": 23,
+        "y": 292,
+        "mask": "eat/maskbc2.png"
+      }
     },
-    "you": {
-      "x": 23,
-      "y": 292,
-      "mask": "eat/maskbc2.png"
-    }
-  }, 
-  "dd": {
-    "name": "逗逗你呀~",
-    "url": "eat/eatdd.png",
-    "you": {
-      "x": 175,
-      "y": 62,
-      "mask": "eat/maskdd.png"
-    }
-  },
-  "dl": {
-    "name": "大佬~可靠",
-    "url": "eat/eatdl.png",
-    "me": {
-      "x": 350,
-      "y": 197,
-      "mask": "eat/maskdl1.png"
+    "dd": {
+      "name": "逗逗你呀~",
+      "url": "eat/eatdd.png",
+      "you": {
+        "x": 175,
+        "y": 62,
+        "mask": "eat/maskdd.png"
+      }
     },
-    "you": {
-      "x": 91,
-      "y": 16,
-      "mask": "eat/maskdl2.png"
-    }
-  },  
-  "fk": {
-    "name": "国际友好手势",
-    "url": "eat/eatfk.png",
-    "me": {
-      "x": 184,
-      "y": 143,
-      "mask": "eat/maskfk.png"
-    }
-  },
-  "fl": {
-    "name": "翻脸",
-    "url": "eat/eatfl.png",
-    "you": {
-      "x": 7,
-      "y": 19,
-      "mask": "eat/maskfl.png"
-    }
-  },     
-  "ko": {
-    "name": "升龙拳",
-    "url": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/eatko.png",
-    "you": {
-      "x": 170,
-      "y": 95,
-      "mask": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/maskko.png"
-    }
-  },
-  "kz": {
-    "name": "看来真得控制你了",
-    "url": "eat/eatkz.png",
-    "you": {
-      "x": 1,
-      "y": 202,
-      "mask": "eat/maskkz.png"
-    }
-  },  
-  "ld": {
-    "name": "我没意见",
-    "url": "eat/eatld.png",
-    "you": {
-      "x": 157,
-      "y": 0,
-      "mask": "eat/maskld.png"
-    }
-  },
-  "ri": {
-    "name": "日一下",
-    "url": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/eatri.png",
-    "you": {
-      "x": 64,
-      "y": 87,
-      "mask": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/maskri.png"
-    }
-  },
-  "sj": {
-    "name": "我会一直视奸你",
-    "url": "eat/eatsj.png",
-    "me": {
-      "x": 118,
-      "y": 42,
-      "brightness": 0.6,
-      "mask": "eat/masksj.png"
-    }
-  },          
-  "tc": {
-    "name": "老汉推车",
-    "url": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/eattc.png",
-    "me": {
-      "x": 224,
-      "y": 173,
-      "mask": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/masktc.png"
+    "dl": {
+      "name": "大佬~可靠",
+      "url": "eat/eatdl.png",
+      "me": {
+        "x": 350,
+        "y": 197,
+        "mask": "eat/maskdl1.png"
+      },
+      "you": {
+        "x": 91,
+        "y": 16,
+        "mask": "eat/maskdl2.png"
+      }
     },
-    "you": {
-      "x": 55,
-      "y": 286,
-      "mask": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/masktc.png"
-    }
-  },
-  "tlg": {
-    "name": "偷撸狗",
-    "url": "eat/eattlg.png",
-    "you": {
-      "x": 16,
-      "y": 280,
-      "mask": "eat/masktlg.png"
-    }
-  },
-  "wyy": {
-    "name": "网抑云时间",
-    "url": "eat/eatwyy.png",
-    "you": {
-      "x": 135,
-      "y": 160,
-      "mask": "eat/maskwyy.png"
-    }
-  },  
-  "wyz": {
-    "name": "我有罪",
-    "url": "eat/eatwyz.png",
-    "you": {
-      "x": 153,
-      "y": 0,
-      "mask": "eat/maskwyz.png"
-    }
-  },
-  "xyy": {
-    "name": "性压抑了",
-    "url": "eat/eatxyy.png",
-    "you": {
-      "x": 146,
-      "y": 0,
-      "mask": "eat/maskxyy.png"
-    }
-  },  
-  "yuyu": {
-    "name": "我有郁郁症",
-    "url": "eat/eatyuyu.png",
-    "you": {
-      "x": 55,
-      "y": 52,
-      "mask": "eat/maskyuyu.png"
+    "fk": {
+      "name": "国际友好手势",
+      "url": "eat/eatfk.png",
+      "me": {
+        "x": 184,
+        "y": 143,
+        "mask": "eat/maskfk.png"
+      }
+    },
+    "fl": {
+      "name": "翻脸",
+      "url": "eat/eatfl.png",
+      "you": {
+        "x": 7,
+        "y": 19,
+        "mask": "eat/maskfl.png"
+      }
+    },
+    "ko": {
+      "name": "升龙拳",
+      "url": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/eatko.png",
+      "you": {
+        "x": 170,
+        "y": 95,
+        "mask": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/maskko.png"
+      }
+    },
+    "kz": {
+      "name": "看来真得控制你了",
+      "url": "eat/eatkz.png",
+      "you": {
+        "x": 1,
+        "y": 202,
+        "mask": "eat/maskkz.png"
+      }
+    },
+    "ld": {
+      "name": "我没意见",
+      "url": "eat/eatld.png",
+      "you": {
+        "x": 157,
+        "y": 0,
+        "mask": "eat/maskld.png"
+      }
+    },
+    "ri": {
+      "name": "日一下",
+      "url": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/eatri.png",
+      "you": {
+        "x": 64,
+        "y": 87,
+        "mask": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/maskri.png"
+      }
+    },
+    "sj": {
+      "name": "我会一直视奸你",
+      "url": "eat/eatsj.png",
+      "me": {
+        "x": 118,
+        "y": 42,
+        "brightness": 0.6,
+        "mask": "eat/masksj.png"
+      }
+    },
+    "tc": {
+      "name": "老汉推车",
+      "url": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/eattc.png",
+      "me": {
+        "x": 224,
+        "y": 173,
+        "mask": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/masktc.png"
+      },
+      "you": {
+        "x": 55,
+        "y": 286,
+        "mask": "https://github.com/FoKit/PagerMaid_Plugins/raw/modify/eat/masktc.png"
+      }
+    },
+    "tlg": {
+      "name": "偷撸狗",
+      "url": "eat/eattlg.png",
+      "you": {
+        "x": 16,
+        "y": 280,
+        "mask": "eat/masktlg.png"
+      }
+    },
+    "wyy": {
+      "name": "网抑云时间",
+      "url": "eat/eatwyy.png",
+      "you": {
+        "x": 135,
+        "y": 160,
+        "mask": "eat/maskwyy.png"
+      }
+    },
+    "wyz": {
+      "name": "我有罪",
+      "url": "eat/eatwyz.png",
+      "you": {
+        "x": 153,
+        "y": 0,
+        "mask": "eat/maskwyz.png"
+      }
+    },
+    "xyy": {
+      "name": "性压抑了",
+      "url": "eat/eatxyy.png",
+      "you": {
+        "x": 146,
+        "y": 0,
+        "mask": "eat/maskxyy.png"
+      }
+    },
+    "yuyu": {
+      "name": "我有郁郁症",
+      "url": "eat/eatyuyu.png",
+      "you": {
+        "x": 55,
+        "y": 52,
+        "mask": "eat/maskyuyu.png"
+      }
     }
   }
- } 
 }


### PR DESCRIPTION
> 更新 config.json 结构:

配置文件被拆分为 meta（元数据）和 resources（资源列表）两个部分。

meta 块中定义了仓库所有者、仓库名、当前分支以及URL模板，作为动态生成资源路径的依据。

> 增强插件逻辑 (eat.ts):

新增 loadConfigResource 逻辑，用于在启动时解析 meta 配置并动态构建资源的基础URL (resourceBaseUrl)。

添加了 resolveResourceUrl 辅助函数，用于将资源列表中的相对路径安全地转换为完整的绝对URL。

修改了所有直接使用资源路径的地方（如 compositeWithEntryConfig 和 iconMaskedFor），强制它们通过 resolveResourceUrl 获取最终路径，以确保配置生效。