### PR TITLE
fix: normalize Telegram placeholder text across plugins

### DIFF
--- a/aitc/aitc.ts
+++ b/aitc/aitc.ts
@@ -228,13 +228,13 @@ async function handleAitcCommand(msg: Api.Message): Promise<void> {
   if (!trimmed) {
     await replyWith(
       "ℹ️ <b>aitc 插件</b>\n\n" +
-        "• <code>aitc key &lt;API Key&gt;</code> - 设置API Key\n" +
-        "• <code>aitc url &lt;地址&gt;</code> - 自定义API地址\n" +
-        "• <code>aitc model &lt;模型名&gt;</code> - 指定模型\n" +
-        `• <code>aitc temp &lt;${TEMPERATURE_RANGE_LABEL}&gt;</code> - 调整温度\n` +
-        "• <code>aitc prompt &lt;系统Prompt&gt;</code> - 定义默认Prompt\n" +
-        "• <code>aitc spn &lt;简称&gt; &lt;Prompt文本&gt;</code> - 保存或更新Prompt预设 (set prompt name)\n" +
-        "• <code>aitc &lt;简称&gt; [文本]</code> - 使用预设Prompt处理文本\n" +
+        "• <code>aitc key ＜API Key＞</code> - 设置API Key\n" +
+        "• <code>aitc url ＜地址＞</code> - 自定义API地址\n" +
+        "• <code>aitc model ＜模型名＞</code> - 指定模型\n" +
+        `• <code>aitc temp ＜${TEMPERATURE_RANGE_LABEL}＞</code> - 调整温度\n` +
+        "• <code>aitc prompt ＜系统Prompt＞</code> - 定义默认Prompt\n" +
+        "• <code>aitc spn ＜简称＞ ＜Prompt文本＞</code> - 保存或更新Prompt预设 (set prompt name)\n" +
+        "• <code>aitc ＜简称＞ [文本]</code> - 使用预设Prompt处理文本\n" +
         "• <code>aitc [文本]</code> - 使用默认Prompt处理文本\n" +
         "• <code>aitc info</code> - 查看当前配置",
     );
@@ -322,7 +322,7 @@ async function handleAitcCommand(msg: Api.Message): Promise<void> {
       if (!aliasToken) {
         await replyWith(
           "❌ <b>请提供Prompt简称与内容</b>\n" +
-            "用法：<code>aitc spn &lt;简称&gt; &lt;Prompt文本&gt;</code>",
+            "用法：<code>aitc spn ＜简称＞ ＜Prompt文本＞</code>",
         );
         return;
       }
@@ -342,7 +342,7 @@ async function handleAitcCommand(msg: Api.Message): Promise<void> {
       if (!promptContent) {
         await replyWith(
           "❌ <b>请提供Prompt内容</b>\n" +
-            "用法：<code>aitc spn &lt;简称&gt; &lt;Prompt文本&gt;</code>",
+            "用法：<code>aitc spn ＜简称＞ ＜Prompt文本＞</code>",
         );
         return;
       }
@@ -425,7 +425,7 @@ async function handleAitcCommand(msg: Api.Message): Promise<void> {
   const apiKey = ConfigManager.get(CONFIG_KEYS.API_KEY, "");
   if (!apiKey) {
     await replyWith(
-      "❌ <b>未配置API Key</b>\n请使用 <code>aitc _set_key &lt;OpenAI Key&gt;</code> 设置后再试",
+      "❌ <b>未配置API Key</b>\n请使用 <code>aitc _set_key ＜OpenAI Key＞</code> 设置后再试",
     );
     return;
   }
@@ -498,13 +498,13 @@ class AitcPlugin extends Plugin {
 
   description: string = `
 自定义 Prompt 的 AI 转写插件：
-- aitc url &lt;地址&gt; - 自定义API地址（兼容OpenAI SDK，默认OpenAI）
-- aitc key &lt;API Key&gt; - 设置API Key
-- aitc model &lt;模型名&gt; - 指定模型（默认gpt-4o-mini）
-- aitc temp &lt;${TEMPERATURE_RANGE_LABEL}&gt; - 调整模型温度（默认0.2）
-- aitc prompt &lt;默认Prompt&gt; - 设置默认Prompt（默认转写为英文）
-- aitc spn &lt;Prompt简称&gt; &lt;Prompt内容&gt; - 保存或更新Prompt预设
-- aitc &lt;Prompt简称&gt; [文本] - 使用预设Prompt处理文本
+- aitc url ＜地址＞ - 自定义API地址（兼容OpenAI SDK，默认OpenAI）
+- aitc key ＜API Key＞ - 设置API Key
+- aitc model ＜模型名＞ - 指定模型（默认gpt-4o-mini）
+- aitc temp ＜${TEMPERATURE_RANGE_LABEL}＞ - 调整模型温度（默认0.2）
+- aitc prompt ＜默认Prompt＞ - 设置默认Prompt（默认转写为英文）
+- aitc spn ＜Prompt简称＞ ＜Prompt内容＞ - 保存或更新Prompt预设
+- aitc ＜Prompt简称＞ [文本] - 使用预设Prompt处理文本
 - aitc [文本] - 使用默认Prompt处理文本
 - aitc info - 查看当前配置
   `;

--- a/autochangename/autochangename.ts
+++ b/autochangename/autochangename.ts
@@ -1270,7 +1270,7 @@ Asia/Tokyo
 Europe/London
 America/New_York
 
-使用 <code>${mainPrefix}acn tz &lt;时区&gt;</code> 设置`, parseMode: "html" });
+使用 <code>${mainPrefix}acn tz ＜时区＞</code> 设置`, parseMode: "html" });
     if (sub === "on" || sub === "off") {
       const settings = await requireSettings(userId, msg);
       if (!settings) return;

--- a/banana/banana.ts
+++ b/banana/banana.ts
@@ -30,8 +30,8 @@ const CONFIG_DEFAULTS: BananaConfig = {
 const help_text =
   "🎯 <b>Nano-Banana 图像编辑插件</b>\n" +
   "• 回复图片并附带 <code>${mainPrefix}banana 提示词</code> 调用 Gemini Nano-Banana 修改图像\n" +
-  "• <code>${mainPrefix}banana key &lt;密钥&gt;</code> 配置 Gemini API Key\n" +
-  "• <code>${mainPrefix}banana limit &lt;数值/MB&gt;</code> 调整图片大小上限（默认 10MB，可用 default 重置）\n" +
+  "• <code>${mainPrefix}banana key ＜密钥＞</code> 配置 Gemini API Key\n" +
+  "• <code>${mainPrefix}banana limit ＜数值/MB＞</code> 调整图片大小上限（默认 10MB，可用 default 重置）\n" +
   "• 使用 ";
 
 const dataDir = createDirectoryInAssets("banana");

--- a/bgp/bgp.ts
+++ b/bgp/bgp.ts
@@ -280,9 +280,9 @@ class BGPPlugin extends Plugin {
 
     description =
         "\n🌐 BGP路由图查询工具\n" +
-        "\n• <code>.bgp &lt;IP&gt;</code> - 查询指定IP的BGP路由图\n" +
+        "\n• <code>.bgp ＜IP＞</code> - 查询指定IP的BGP路由图\n" +
         "• <code>.bgp</code> - 回复包含IP的消息自动查询BGP路由图\n" +
-        "• <code>.bgp dns &lt;IP&gt;</code> - 查询指定IP的DNS解析记录\n" +
+        "• <code>.bgp dns ＜IP＞</code> - 查询指定IP的DNS解析记录\n" +
         "• <code>.bgp dns</code> - 回复包含IP的消息查询DNS解析记录";
 
     cmdHandlers: Record<string, (msg: Api.Message, trigger?: Api.Message) => Promise<void>> = {

--- a/bulk_delete/bulk_delete.ts
+++ b/bulk_delete/bulk_delete.ts
@@ -248,7 +248,7 @@ class BulkDeletePlugin extends Plugin {
     // 当前插件不持有需要在 reload 时额外释放的长期资源。
   }
 
-  description: string = `回复消息并使用 ${mainPrefix}bd, 删除从被回复的消息到当前指令之间的所有消息。或使用 ${mainPrefix}bd <数字> 删除您最近的消息。使用 ${mainPrefix}bd on/off 切换删除他人消息的权限。`;
+  description: string = `回复消息并使用 ${mainPrefix}bd, 删除从被回复的消息到当前指令之间的所有消息。或使用 ${mainPrefix}bd ＜数字＞ 删除您最近的消息。使用 ${mainPrefix}bd on/off 切换删除他人消息的权限。`;
   cmdHandlers: Record<string, (msg: Api.Message) => Promise<void>> = {
     bd,
   };

--- a/clean_member/clean_member.ts
+++ b/clean_member/clean_member.ts
@@ -516,13 +516,13 @@ function getHelpText(): string {
   return `<b>🧹 群成员清理工具 Pro</b>
 
 <b>🔧 使用格式:</b>
-<code>${mainPrefix}clean_member &lt;模式&gt; &lt;参数&gt; [chat:-100xxx] [limit:数量] [search]</code>
+<code>${mainPrefix}clean_member ＜模式＞ ＜参数＞ [chat:-100xxx] [limit:数量] [search]</code>
 
 <b>📋 清理模式:</b>
 ┌─────────────────────────
-│ <b>1</b> &lt;天数&gt; → 未上线超过N天
-│ <b>2</b> &lt;天数&gt; → 未发言超过N天  
-│ <b>3</b> &lt;数量&gt; → 发言少于N条
+│ <b>1</b> ＜天数＞ → 未上线超过N天
+│ <b>2</b> ＜天数＞ → 未发言超过N天  
+│ <b>3</b> ＜数量＞ → 发言少于N条
 │ <b>4</b> → 已注销账户
 │ <b>5</b> → 所有普通成员 ⚠️
 └─────────────────────────

--- a/copy_sticker_set/copy_sticker_set.ts
+++ b/copy_sticker_set/copy_sticker_set.ts
@@ -25,10 +25,10 @@ class CopyStickerSetPlugin extends Plugin {
 
   description: string = `📦 <b>复制贴纸包</b><br/><br/>
 <b>命令格式</b><br/>
-• <code>${mainPrefix}copy_sticker_set &lt;贴纸包&gt; [自定义名称] [limit=数字]</code><br/>
-• <code>.css &lt;贴纸包&gt; [自定义名称] [limit=数字]</code><br/><br/>
+• <code>${mainPrefix}copy_sticker_set ＜贴纸包＞ [自定义名称] [limit=数字]</code><br/>
+• <code>.css ＜贴纸包＞ [自定义名称] [limit=数字]</code><br/><br/>
 <b>参数说明</b><br/>
-• <code>&lt;贴纸包&gt;</code> - 贴纸包链接或短名称（必填）<br/>
+• <code>＜贴纸包＞</code> - 贴纸包链接或短名称（必填）<br/>
 • <code>[自定义名称]</code> - 新贴纸包的标题（可选）<br/>
 • <code>[limit=数字]</code> - 限制复制数量（最大 120，默认 100）<br/><br/>
 <b>使用示例</b><br/>
@@ -62,16 +62,15 @@ class CopyStickerSetPlugin extends Plugin {
       const lines = (msg.text || '').split('\n');
       const parts = lines[0].split(' ');
       const args = parts.slice(1); // 移除命令部分
-      const fullText = lines.slice(1).join('\n'); // 多行内容
       
       if (args.length === 0) {
         await msg.edit({
            text: "📋 <b>复制贴纸包使用说明</b><br/><br/>" +
                  "<b>命令格式</b><br/>" +
-                 "<code>${mainPrefix}copy_sticker_set &lt;贴纸包&gt; [自定义名称] [limit=数字]</code><br/>" +
-                 "<code>.css &lt;贴纸包&gt; [自定义名称] [limit=数字]</code><br/><br/>" +
+                 "<code>${mainPrefix}copy_sticker_set ＜贴纸包＞ [自定义名称] [limit=数字]</code><br/>" +
+                 "<code>.css ＜贴纸包＞ [自定义名称] [limit=数字]</code><br/><br/>" +
                  "<b>参数说明</b><br/>" +
-                 "• <code>&lt;贴纸包&gt;</code> - 贴纸包链接或短名称（必填）<br/>" +
+                 "• <code>＜贴纸包＞</code> - 贴纸包链接或短名称（必填）<br/>" +
                  "• <code>[自定义名称]</code> - 新贴纸包的标题（可选）<br/>" +
                  "• <code>[limit=数字]</code> - 限制复制数量（最大 120，默认 100）<br/><br/>" +
                  "<b>使用示例</b><br/>" +
@@ -104,7 +103,7 @@ class CopyStickerSetPlugin extends Plugin {
         if (m) {
           const v = parseInt(m[1], 10);
           if (!Number.isFinite(v) || v <= 0) {
-            const prefixes = await getPrefixes();
+            const prefixes = getPrefixes();
             await msg.edit({ 
               text: `<b>❌ 参数错误</b><br/><br/>limit 参数无效，请使用 <code>limit=正整数</code>（最大120）<br/><br/>使用 <code>${prefixes[0]}copy_sticker_set</code> 查看帮助`,
               parseMode: "html"
@@ -112,9 +111,9 @@ class CopyStickerSetPlugin extends Plugin {
             return;
           }
           if (v > 120) {
-            const prefixes = await getPrefixes();
+            const prefixes = getPrefixes();
             await msg.edit({ 
-              text: `<b>❌ 参数错误</b><br/><br/>平台限制：最多 120 张贴纸。请调整 <code>limit&lt;=120</code><br/><br/>使用 <code>${prefixes[0]}copy_sticker_set</code> 查看帮助`,
+               text: `<b>❌ 参数错误</b><br/><br/>平台限制：最多 120 张贴纸。请调整 <code>limit 小于等于 120</code><br/><br/>使用 <code>${prefixes[0]}copy_sticker_set</code> 查看帮助`,
               parseMode: "html"
             });
             return;
@@ -132,7 +131,7 @@ class CopyStickerSetPlugin extends Plugin {
         if (match) {
           stickerSetName = match[1];
         } else {
-          const prefixes = await getPrefixes();
+          const prefixes = getPrefixes();
           await msg.edit({
             text: `<b>❌ 链接格式错误</b><br/><br/>无效的贴纸包链接格式<br/><br/>使用 <code>${prefixes[0]}copy_sticker_set</code> 查看帮助`,
             parseMode: "html"
@@ -160,7 +159,7 @@ class CopyStickerSetPlugin extends Plugin {
         if ('set' in result && 'documents' in result) {
           stickerSet = result as Api.messages.StickerSet;
         } else {
-          const prefixes = await getPrefixes();
+          const prefixes = getPrefixes();
           await msg.edit({
             text: `<b>❌ 获取失败</b><br/><br/>获取贴纸包信息失败<br/><br/>使用 <code>${prefixes[0]}copy_sticker_set</code> 查看帮助`,
             parseMode: "html"
@@ -169,7 +168,7 @@ class CopyStickerSetPlugin extends Plugin {
         }
       } catch (error) {
         console.error('Failed to get sticker set:', error);
-        const prefixes = await getPrefixes();
+        const prefixes = getPrefixes();
         await msg.edit({
           text: `<b>❌ 贴纸包不存在</b><br/><br/>无法找到贴纸包：<code>${htmlEscape(stickerSetName)}</code><br/>请检查贴纸包名称是否正确<br/><br/>使用 <code>${prefixes[0]}copy_sticker_set</code> 查看帮助`,
           parseMode: "html"
@@ -181,7 +180,7 @@ class CopyStickerSetPlugin extends Plugin {
       const stickers = stickerSet.documents;
       
       if (!stickers || stickers.length === 0) {
-        const prefixes = await getPrefixes();
+        const prefixes = getPrefixes();
         await msg.edit({
           text: `<b>❌ 贴纸包为空</b><br/><br/>贴纸包中没有贴纸<br/><br/>使用 <code>${prefixes[0]}copy_sticker_set</code> 查看帮助`,
           parseMode: "html"
@@ -256,7 +255,7 @@ class CopyStickerSetPlugin extends Plugin {
       }
 
       if (stickerInputs.length === 0) {
-        const prefixes = await getPrefixes();
+        const prefixes = getPrefixes();
         await msg.edit({
           text: `<b>❌ 处理失败</b><br/><br/>无法处理任何贴纸<br/><br/>使用 <code>${prefixes[0]}copy_sticker_set</code> 查看帮助`,
           parseMode: "html"
@@ -295,7 +294,7 @@ class CopyStickerSetPlugin extends Plugin {
             text: `✅ 贴纸包复制成功！\n\n📦 原贴纸包：${htmlEscape(originalSet.title)}\n🆕 新贴纸包：${htmlEscape(finalTitle)}\n🔗 链接：${newSetUrl}\n📊 贴纸数量：${stickerInputs.length}（limit=${desired}）\n\n点击链接添加到 Telegram！`
           });
         } else {
-          const prefixes = await getPrefixes();
+          const prefixes = getPrefixes();
           await msg.edit({
             text: `<b>❌ 创建失败</b><br/><br/>创建贴纸包失败，请稍后重试<br/><br/>使用 <code>${prefixes[0]}copy_sticker_set</code> 查看帮助`,
             parseMode: "html"
@@ -305,7 +304,7 @@ class CopyStickerSetPlugin extends Plugin {
       } catch (createError) {
         console.error("Failed to create sticker set:", createError);
         
-        const prefixes = await getPrefixes();
+        const prefixes = getPrefixes();
         let errorMsg = `<b>❌ 创建错误</b><br/><br/>创建贴纸包时出现错误<br/><br/>使用 <code>${prefixes[0]}copy_sticker_set</code> 查看帮助`;
         
         if (createError instanceof Error) {
@@ -328,7 +327,7 @@ class CopyStickerSetPlugin extends Plugin {
       
     } catch (error) {
       console.error("CopyStickerSet plugin error:", error);
-      const prefixes = await getPrefixes();
+      const prefixes = getPrefixes();
       await msg.edit({
         text: `<b>❌ 插件错误</b><br/><br/>复制贴纸包时出现错误：<code>${htmlEscape(error instanceof Error ? error.message : String(error))}</code><br/><br/>使用 <code>${prefixes[0]}copy_sticker_set</code> 查看帮助`,
         parseMode: "html"

--- a/deepwiki/deepwiki.ts
+++ b/deepwiki/deepwiki.ts
@@ -571,19 +571,19 @@ class DeepWikiPlugin extends Plugin {
       `<b>📚 DeepWiki 插件</b>\n\n` +
       `DeepWiki通过与Github上的项目建立索引可以解决目前普遍的Ai信息滞后问题来精准回答您的提问\n\n` +
       `<b>🗂️ 项目管理</b>\n` +
-      `• <code>${p}deepwiki add &lt;tag&gt; &lt;url&gt;</code>（添加新的项目）\n` +
+      `• <code>${p}deepwiki add ＜tag＞ ＜url＞</code>（添加新的项目）\n` +
       `• <code>${p}deepwiki lst</code>（已添加的项目）\n` +
-      `• <code>${p}deepwiki use &lt;tag&gt;</code>（切换默认项目）\n` +
-      `• <code>${p}deepwiki del &lt;tag&gt;</code>（删除指定项目）\n\n` +
+      `• <code>${p}deepwiki use ＜tag＞</code>（切换默认项目）\n` +
+      `• <code>${p}deepwiki del ＜tag＞</code>（删除指定项目）\n\n` +
       `<b>📜 上下文管理</b>\n` +
       `• <code>${p}deepwiki ctx</code>（上下文状态）\n` +
       `• <code>${p}deepwiki ctx on/off</code>（开启或关闭上下文）\n` +
       `• <code>${p}deepwiki ctx del</code>（清空当前项目上下文）\n` +
-      `• <code>${p}deepwiki ctx del &lt;tag&gt;</code>（清空指定项目上下文）\n` +
+      `• <code>${p}deepwiki ctx del ＜tag＞</code>（清空指定项目上下文）\n` +
       `• <code>${p}deepwiki ctx del all</code>（清空全部项目上下文）\n\n` +
       `<b>📌 使用说明</b>\n` +
       `• <code>${p}deepwiki 你的问题</code>（发起默认项目提问）\n` +
-      `• <code>${p}deepwiki &lt;tag&gt; 你的问题</code>（发起指定项目提问）\n\n` +
+      `• <code>${p}deepwiki ＜tag＞ 你的问题</code>（发起指定项目提问）\n\n` +
       `说明：项目需要能在 deepwiki.com 上正常访问（已索引）。`
     );
   }
@@ -698,7 +698,7 @@ class DeepWikiPlugin extends Plugin {
           if (entries.length === 0) {
             await MessageSender.sendOrEdit(
               original,
-              `暂无项目。\n用 <code>${this.getMainPrefix()}deepwiki add &lt;tag&gt; &lt;url&gt;</code> 添加。`,
+              `暂无项目。\n用 <code>${this.getMainPrefix()}deepwiki add ＜tag＞ ＜url＞</code> 添加。`,
               "html"
             );
             return;
@@ -715,7 +715,7 @@ class DeepWikiPlugin extends Plugin {
           return;
         }
         if (sub === "use") {
-          requireUser(args.length >= 2, `用法：<code>${this.getMainPrefix()}deepwiki use &lt;tag&gt;</code>`);
+          requireUser(args.length >= 2, `用法：<code>${this.getMainPrefix()}deepwiki use ＜tag＞</code>`);
           const tag = normalizeTag(args[1]);
           requireUser(!!state.repos?.[tag], `项目不存在：<code>${escapeHtml(tag)}</code>`);
           await this.store.setCurrent(chatKey, tag);
@@ -728,7 +728,7 @@ class DeepWikiPlugin extends Plugin {
           return;
         }
         if (sub === "del") {
-          requireUser(args.length >= 2, `用法：<code>${this.getMainPrefix()}deepwiki del &lt;tag&gt;</code>`);
+          requireUser(args.length >= 2, `用法：<code>${this.getMainPrefix()}deepwiki del ＜tag＞</code>`);
           const tag = normalizeTag(args[1]);
           const ok = await this.store.deleteRepo(chatKey, tag);
           requireUser(ok, `项目不存在：<code>${escapeHtml(tag)}</code>`);
@@ -736,9 +736,9 @@ class DeepWikiPlugin extends Plugin {
           return;
         }
         if (sub === "add") {
-          requireUser(args.length >= 3, `用法：<code>${this.getMainPrefix()}deepwiki add &lt;tag&gt; &lt;url&gt;</code>`);
+          requireUser(args.length >= 3, `用法：<code>${this.getMainPrefix()}deepwiki add ＜tag＞ ＜url＞</code>`);
           const tagArg = normalizeTag(args[1]);
-          requireUser(/^[A-Za-z0-9_.-]+$/.test(tagArg), "&lt;tag&gt; 只能包含字母/数字/下划线/点/短横线");
+          requireUser(/^[A-Za-z0-9_.-]+$/.test(tagArg), "＜tag＞ 只能包含字母/数字/下划线/点/短横线");
           const parsed = parseRepoFromUrl(args[2]);
           requireUser(!!parsed, "链接格式不正确，仅支持 deepwiki.com 或 github.com");
           const entry: RepoEntry = {
@@ -780,7 +780,7 @@ class DeepWikiPlugin extends Plugin {
 
             const tagArg = args[2] ? normalizeTag(args[2]) : "";
             const tagToClear = tagArg || state.currentTag;
-            requireUser(!!tagToClear, "未指定 <tag>，且当前也没有默认项目。用法：<code>deepwiki ctx del &lt;tag&gt;</code>");
+            requireUser(!!tagToClear, "未指定 ＜tag＞，且当前也没有默认项目。用法：<code>deepwiki ctx del ＜tag＞</code>");
             if (tagArg) {
               requireUser(!!state.repos?.[tagArg], `项目不存在：<code>${escapeHtml(tagArg)}</code>`);
             }

--- a/eatgif/eatgif.ts
+++ b/eatgif/eatgif.ts
@@ -186,7 +186,7 @@ class EatGifPlugin extends Plugin {
     const items = keys.map(
       (k) => `• <code>${htmlEscape(k)}</code> - ${htmlEscape(config[k].desc)}`
     );
-    const header = `🧩 <b>可用表情列表</b>\n使用：<code>${commandName} &lt;名称&gt;</code>（需回复Ta）\n\n`;
+    const header = `🧩 <b>可用表情列表</b>\n使用：<code>${commandName} ＜名称＞</code>（需回复Ta）\n\n`;
     return header + items.join("\n");
   }
 
@@ -194,12 +194,6 @@ class EatGifPlugin extends Plugin {
     fs.rmSync(ASSET_PATH, { recursive: true, force: true });
     await loadGifListConfig(baseConfigURL);
     await msg.edit({ text: "🧹 已清理缓存并刷新配置", parseMode: "html" });
-  }
-
-  private getRandomEatGif(): string {
-    let keys = Object.keys(config);
-    const randomIndex = Math.floor(Math.random() * keys.length);
-    return keys[randomIndex];
   }
 
   private async generateGif(
@@ -410,12 +404,6 @@ class EatGifPlugin extends Plugin {
     return youAvatarBuffer as Buffer | undefined;
   }
 
-  private async getMediaAvatarBuffer(
-    msg: Api.Message,
-    trigger?: Api.Message
-  ): Promise<Buffer | undefined> {
-    return;
-  }
 }
 
 export default new EatGifPlugin();

--- a/fadian/fadian.ts
+++ b/fadian/fadian.ts
@@ -219,7 +219,7 @@ class FadianPlugin extends Plugin {
 
             if (!targetName) {
               await msg.edit({
-                text: `❌ <b>参数不足</b>\n\n💡 使用方法：\n1. <code>${mainPrefix}fadian fd &lt;名字&gt;</code>\n2. 回复某人消息后使用 <code>${mainPrefix}fadian fd</code>\n\n示例：<code>${mainPrefix}fadian fd 张三</code>`,
+                text: `❌ <b>参数不足</b>\n\n💡 使用方法：\n1. <code>${mainPrefix}fadian fd ＜名字＞</code>\n2. 回复某人消息后使用 <code>${mainPrefix}fadian fd</code>\n\n示例：<code>${mainPrefix}fadian fd 张三</code>`,
                 parseMode: "html",
               });
               return;

--- a/git_PR/git_PR.ts
+++ b/git_PR/git_PR.ts
@@ -53,11 +53,11 @@ const pluginName = "git";
 const help_text = `⚙️ <b>Git PR 管理插件</b>
 
 <b>命令:</b>
-• <code>${mainPrefix}${pluginName} login &lt;邮箱&gt; &lt;用户名&gt; &lt;Token&gt;</code> - 登录Git
+• <code>${mainPrefix}${pluginName} login ＜邮箱＞ ＜用户名＞ ＜Token＞</code> - 登录Git
 • <code>${mainPrefix}${pluginName} repos</code> - 列出有编辑权限的仓库
-• <code>${mainPrefix}${pluginName} prs &lt;仓库名&gt;</code> - 列出仓库的PR
-• <code>${mainPrefix}${pluginName} merge &lt;仓库名&gt; &lt;PR编号&gt;</code> - 合并PR
-• <code>${mainPrefix}${pluginName} mergeall &lt;仓库名&gt;</code> - 按序号合并所有可合并的PR
+• <code>${mainPrefix}${pluginName} prs ＜仓库名＞</code> - 列出仓库的PR
+• <code>${mainPrefix}${pluginName} merge ＜仓库名＞ ＜PR编号＞</code> - 合并PR
+• <code>${mainPrefix}${pluginName} mergeall ＜仓库名＞</code> - 按序号合并所有可合并的PR
 • <code>${mainPrefix}${pluginName} help</code> - 显示此帮助消息`;
 
 // 配置键
@@ -194,7 +194,7 @@ class GitManagerPlugin extends Plugin {
 
   private async handleLogin(msg: Api.Message, args: string[]) {
     if (args.length < 3) {
-      await msg.edit({ text: `❌ <b>参数不足</b>\n\n<b>格式:</b> <code>${mainPrefix}${pluginName} login &lt;邮箱&gt; &lt;用户名&gt; &lt;Token&gt;</code>`, parseMode: "html" });
+        await msg.edit({ text: `❌ <b>参数不足</b>\n\n<b>格式:</b> <code>${mainPrefix}${pluginName} login ＜邮箱＞ ＜用户名＞ ＜Token＞</code>`, parseMode: "html" });
       return;
     }
 

--- a/ip/ip.ts
+++ b/ip/ip.ts
@@ -107,8 +107,8 @@ const ip = async (msg: Api.Message) => {
         text: `📍 <b>IP查询插件</b>
 
 <b>使用方法：</b>
-• <code>ip &lt;IP地址&gt;</code>
-• <code>ip &lt;域名&gt;</code>
+• <code>ip ＜IP地址＞</code>
+• <code>ip ＜域名＞</code>
 • 回复包含IP/域名的消息后使用 <code>ip</code>
 
 <b>示例：</b>

--- a/komari/komari.ts
+++ b/komari/komari.ts
@@ -636,10 +636,10 @@ async function handleKomariRequest(msg: Api.Message): Promise<void> {
         text: `❌ 未知命令。支持的命令：
 • <code>komari status</code> - 获取服务器基本信息
 • <code>komari total</code> - 获取节点总览
-• <code>komari show &lt;节点名&gt;</code> - 查看指定节点详情
+• <code>komari show ＜节点名＞</code> - 查看指定节点详情
 
 配置命令：
-• <code>komari _set_url &lt;URL&gt;</code> - 设置 Komari 服务器 URL`,
+• <code>komari _set_url ＜URL＞</code> - 设置 Komari 服务器 URL`,
         parseMode: "html",
       });
     }
@@ -667,10 +667,10 @@ Komari 服务器监控插件：
 命令：
 • <code>komari status</code> - 获取服务器基本信息
 • <code>komari total</code> - 获取所有节点总览
-• <code>komari show &lt;节点名&gt;</code> - 查看指定节点详细状态
+• <code>komari show ＜节点名＞</code> - 查看指定节点详细状态
 
 配置命令：
-• <code>komari _set_url &lt;URL&gt;</code> - 设置 Komari 服务器地址
+• <code>komari _set_url ＜URL＞</code> - 设置 Komari 服务器地址
   `;
   cmdHandlers: Record<string, (msg: Api.Message) => Promise<void>> = {
     komari: handleKomariRequest,

--- a/qr/qr.ts
+++ b/qr/qr.ts
@@ -192,7 +192,7 @@ class QRPlugin extends Plugin {
 使用前请先安装依赖。
 
 ━━━ 核心功能 ━━━
-• <code>qr &lt;文本&gt;</code> - 直接生成二维码
+• <code>qr ＜文本＞</code> - 直接生成二维码
 • 回复文本消息使用 <code>qr</code> - 将消息内容转为二维码
 • 回复图片使用 <code>qr</code> - 解码图中的二维码内容
 
@@ -321,7 +321,7 @@ class QRPlugin extends Plugin {
         // 4. 如果没有任何有效输入，显示帮助信息
         await msg.edit({
           text: 'ℹ️ <b>QR 工具使用方法:</b>\n\n' +
-            '• <code>qr &lt;文本&gt;</code>\n  (将文本转为二维码)\n\n' +
+            '• <code>qr ＜文本＞</code>\n  (将文本转为二维码)\n\n' +
             '• 回复文本消息使用 <code>qr</code>\n  (将消息内容转为二维码)\n\n' +
             '• 回复图片/贴纸使用 <code>qr</code>\n  (解码图中的二维码)',
           parseMode: 'html'

--- a/service/service.ts
+++ b/service/service.ts
@@ -1,22 +1,9 @@
 import { Plugin } from "@utils/pluginBase";
-import { Api, TelegramClient } from "teleproto";
+import { Api } from "teleproto";
 import { exec } from "child_process";
 import { promisify } from "util";
-import * as os from "os";
 
 const execAsync = promisify(exec);
-
-// 配置存储键名
-const CONFIG_KEYS = {
-  SERVICE_DEFAULT: "service_default",
-  SERVICE_AUTO_DETECT: "service_auto_detect",
-};
-
-// 默认配置
-const DEFAULT_CONFIG = {
-  [CONFIG_KEYS.SERVICE_DEFAULT]: "pagermaid",
-  [CONFIG_KEYS.SERVICE_AUTO_DETECT]: "true",
-};
 
 // 状态翻译映射
 const STATUS_TRANSLATIONS: Record<string, string> = {
@@ -173,7 +160,7 @@ function translateToChinese(text: string): string {
       // 提取时间部分并格式化
       const timeMatch = line.match(/(启动时间:|Started:)\s*(.+)/);
       if (timeMatch) {
-        const [, label, timePart] = timeMatch;
+          const [, , timePart] = timeMatch;
         const formattedTime = formatChineseTime(timePart);
         translatedLine = `启动时间: ${formattedTime}`;
       }
@@ -317,7 +304,7 @@ class ServicePlugin extends Plugin {
 
 使用方法：
 • \`service\` - 自动检测并显示当前服务状态
-• \`service <服务名>\` - 显示指定服务的状态
+• \`service ＜服务名＞\` - 显示指定服务的状态
 
 功能特点：
 • 自动检测当前进程对应的systemd服务

--- a/speedlink/speedlink.ts
+++ b/speedlink/speedlink.ts
@@ -375,29 +375,29 @@ sudo yum install speedtest</code></pre>
 <b>服务器管理指令:</b>
 
 - <b>添加服务器 (密码认证):</b>
-  <code>sl add &lt;别名&gt; &lt;user@host:port&gt; password &lt;密码&gt;</code>
+  <code>sl add ＜别名＞ ＜user@host:port＞ password ＜密码＞</code>
   <i>示例:</i> <code>sl add 东京-甲骨文 root@1.2.3.4:22 password MyPassword123</code>
 
 - <b>添加服务器 (密钥认证):</b>
-  <code>sl add &lt;别名&gt; &lt;user@host:port&gt; key &lt;私钥路径&gt;</code>
+  <code>sl add ＜别名＞ ＜user@host:port＞ key ＜私钥路径＞</code>
   <i>注意: 私钥路径是指在<b>运行TeleBox的服务器上</b>的绝对路径。</i>
   <i>示例:</i> <code>sl add 法兰克福-谷歌 ubuntu@5.6.7.8:22 key /root/.ssh/id_rsa</code>
 
 - <b>查看服务器列表:</b> <code>sl list</code>
-- <b>删除服务器:</b> <code>sl del &lt;显示序号&gt;</code>
-- <b>🆕 修改别名:</b> <code>sl rename &lt;显示序号&gt; &lt;新别名&gt;</code>
+- <b>删除服务器:</b> <code>sl del ＜显示序号＞</code>
+- <b>🆕 修改别名:</b> <code>sl rename ＜显示序号＞ ＜新别名＞</code>
 ---
 <b>执行测速指令:</b>
 
-- <b>远程测速:</b> <code>sl &lt;显示序号&gt;</code>
+- <b>远程测速:</b> <code>sl ＜显示序号＞</code>
 - <b>本机测速:</b> <code>sl</code>
 - <b>多服务器测速:</b> <code>sl 1 3 5</code>
 - <b>全部测速:</b> <code>sl all</code>
-- <b>🆕 排除测速:</b> <code>sl all no &lt;序号1&gt; &lt;序号2&gt;</code>
+- <b>🆕 排除测速:</b> <code>sl all no ＜序号1＞ ＜序号2＞</code>
 ---
 <b>配置指令:</b>
 
-- <b>设置超时时间:</b> <code>sl timeout &lt;秒数&gt;</code>
+- <b>设置超时时间:</b> <code>sl timeout ＜秒数＞</code>
   <i>示例:</i> <code>sl timeout 60</code> (设置60秒超时)
   <i>默认值: 300秒 (5分钟)</i>
 - <b>查看当前超时:</b> <code>sl timeout</code>
@@ -456,7 +456,7 @@ const speedtest = async (msg: Api.Message): Promise<void> => {
       } else {
         const currentTimeout = DEFAULT_TIMEOUT / 1000;
         await msg.edit({
-          text: `ℹ️ <b>当前超时设置</b>\n\n超时时间: <code>${currentTimeout}</code> 秒\n\n使用 <code>sl timeout &lt;秒数&gt;</code> 来修改`,
+            text: `ℹ️ <b>当前超时设置</b>\n\n超时时间: <code>${currentTimeout}</code> 秒\n\n使用 <code>sl timeout ＜秒数＞</code> 来修改`,
           parseMode: "html",
         });
       }
@@ -563,7 +563,7 @@ const speedtest = async (msg: Api.Message): Promise<void> => {
         const newName = args.slice(2).join(" ");
         if (isNaN(displayId) || displayId < 1 || !newName) {
           await msg.edit({
-            text: "❌ <b>参数错误</b>\n\n请使用: <code>sl rename &lt;显示序号&gt; &lt;新别名&gt;</code>",
+            text: "❌ <b>参数错误</b>\n\n请使用: <code>sl rename ＜显示序号＞ ＜新别名＞</code>",
             parseMode: "html",
           });
           return;

--- a/sum/sum.ts
+++ b/sum/sum.ts
@@ -286,10 +286,6 @@ async function formatEntity(target: any) {
   };
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 // AI 调用函数
 async function callOpenAI(
   apiKey: string,
@@ -853,7 +849,7 @@ const help_text = `▎群消息总结
 <code>${mainPrefix}sum 200 --provider gemini</code> - 指定数量和AI配置
 
 <b>📋 定时总结：</b>
-<code>${mainPrefix}sum add &lt;群组标识&gt; &lt;间隔&gt; [消息数] [选项]</code>
+<code>${mainPrefix}sum add ＜群组标识＞ ＜间隔＞ [消息数] [选项]</code>
 群组标识支持:
   • 数字ID: -1001234567890
   • 公开链接: t.me/groupname 或 https://t.me/groupname
@@ -864,8 +860,8 @@ const help_text = `▎群消息总结
   • Cron表达式(6字段): 0 0 9,15,21 * * * (每天9:00,15:00,21:00)
   • Cron表达式(5字段): 30 */2 * * * (自动补秒字段)
 选项:
-  --time &lt;小时&gt; - 按时间范围总结（如 --time 2 表示过去2小时）
-  --provider &lt;名称&gt; - 指定AI配置
+  --time ＜小时＞ - 按时间范围总结（如 --time 2 表示过去2小时）
+  --provider ＜名称＞ - 指定AI配置
   --spoiler - 启用折叠显示
   --no-spoiler - 禁用折叠显示（覆盖全局设置）
 示例:
@@ -875,35 +871,35 @@ const help_text = `▎群消息总结
 
 <b>🔧 管理命令：</b>
 • <code>${mainPrefix}sum list</code> - 列出所有任务（按ID排序）
-• <code>${mainPrefix}sum del &lt;任务ID&gt;</code> - 删除任务
-• <code>${mainPrefix}sum run &lt;任务ID&gt;</code> - 立即运行任务
-• <code>${mainPrefix}sum edit &lt;任务ID&gt; &lt;属性&gt; &lt;值&gt;</code> - 修改任务属性
+• <code>${mainPrefix}sum del ＜任务ID＞</code> - 删除任务
+• <code>${mainPrefix}sum run ＜任务ID＞</code> - 立即运行任务
+• <code>${mainPrefix}sum edit ＜任务ID＞ ＜属性＞ ＜值＞</code> - 修改任务属性
   属性: spoiler (on/off) | provider (配置名) | prompt (提示词)
   留空值则使用全局配置
-• <code>${mainPrefix}sum disable/enable &lt;任务ID&gt;</code> - 禁用/启用任务
+• <code>${mainPrefix}sum disable/enable ＜任务ID＞</code> - 禁用/启用任务
 • <code>${mainPrefix}sum reorder</code> - 从1开始重新编号所有任务
 
 <b>🤖 AI 配置管理：</b>
 • <code>${mainPrefix}sum config list</code> - 列出所有配置
-• <code>${mainPrefix}sum config add &lt;官方名称&gt; &lt;API_KEY&gt;</code> - 快速添加官方 (openai/gemini)
+• <code>${mainPrefix}sum config add ＜官方名称＞ ＜API_KEY＞</code> - 快速添加官方 (openai/gemini)
   示例: <code>${mainPrefix}sum config add openai sk-xxx</code>
-• <code>${mainPrefix}sum config add &lt;名称&gt; &lt;类型&gt; &lt;BaseURL&gt; &lt;Model&gt;</code> - 自定义服务商
+• <code>${mainPrefix}sum config add ＜名称＞ ＜类型＞ ＜BaseURL＞ ＜Model＞</code> - 自定义服务商
   类型: openai 或 gemini
   示例: <code>${mainPrefix}sum config add deepseek openai https://api.deepseek.com deepseek-chat</code>
-• <code>${mainPrefix}sum config set &lt;名称&gt; key &lt;API_KEY&gt;</code> - 设置API Key
-• <code>${mainPrefix}sum config set &lt;名称&gt; model &lt;模型&gt;</code> - 修改模型
-• <code>${mainPrefix}sum config set &lt;名称&gt; url &lt;URL&gt;</code> - 修改Base URL
-• <code>${mainPrefix}sum config del &lt;名称&gt;</code> - 删除配置
+• <code>${mainPrefix}sum config set ＜名称＞ key ＜API_KEY＞</code> - 设置API Key
+• <code>${mainPrefix}sum config set ＜名称＞ model ＜模型＞</code> - 修改模型
+• <code>${mainPrefix}sum config set ＜名称＞ url ＜URL＞</code> - 修改Base URL
+• <code>${mainPrefix}sum config del ＜名称＞</code> - 删除配置
 
 <b>⚙️ 全局设置：</b>
-• <code>${mainPrefix}sum config set push &lt;目标&gt;</code> - 设置默认推送目标
-• <code>${mainPrefix}sum config set default &lt;名称&gt;</code> - 设置默认配置
-• <code>${mainPrefix}sum config set prompt &lt;提示词&gt;</code> - 设置总结提示词
+• <code>${mainPrefix}sum config set push ＜目标＞</code> - 设置默认推送目标
+• <code>${mainPrefix}sum config set default ＜名称＞</code> - 设置默认配置
+• <code>${mainPrefix}sum config set prompt ＜提示词＞</code> - 设置总结提示词
 • <code>${mainPrefix}sum config set prompt reset</code> - 重置提示词为默认值
 • <code>${mainPrefix}sum config set spoiler on/off</code> - 全局折叠开关
-• <code>${mainPrefix}sum config set timeout &lt;秒数&gt;</code> - 设置AI超时时间（默认60秒）
+• <code>${mainPrefix}sum config set timeout ＜秒数＞</code> - 设置AI超时时间（默认60秒）
 • <code>${mainPrefix}sum config set reply on/off</code> - 回复模式（发送新消息，防止被顶走，默认开启）
-• <code>${mainPrefix}sum config set maxoutput &lt;字符数&gt;</code> - 最大输出长度（0不限制，默认不限制）
+• <code>${mainPrefix}sum config set maxoutput ＜字符数＞</code> - 最大输出长度（0不限制，默认不限制）
 • <code>${mainPrefix}sum prompts</code> - 查看推荐提示词
 `;
 
@@ -1173,7 +1169,7 @@ class SummaryPlugin extends Plugin {
 
           if (!chatIdInput || !intervalInput) {
             await msg.edit({
-              text: `❌ 格式错误\n\n用法: <code>${mainPrefix}sum add &lt;群组标识&gt; &lt;间隔&gt; [消息数] [选项]</code>\n\n群组标识支持:\n• 数字ID: -1001234567890\n• 链接: t.me/groupname\n• 用户名: @groupname\n\n示例: <code>${mainPrefix}sum add -1001234567890 2h</code>`,
+              text: `❌ 格式错误\n\n用法: <code>${mainPrefix}sum add ＜群组标识＞ ＜间隔＞ [消息数] [选项]</code>\n\n群组标识支持:\n• 数字ID: -1001234567890\n• 链接: t.me/groupname\n• 用户名: @groupname\n\n示例: <code>${mainPrefix}sum add -1001234567890 2h</code>`,
               parseMode: "html"
             });
             return;
@@ -1394,7 +1390,7 @@ class SummaryPlugin extends Plugin {
 
           if (!id || !prop) {
             await msg.edit({
-              text: `❌ 格式错误\n\n用法: <code>${mainPrefix}sum edit &lt;任务ID&gt; &lt;属性&gt; &lt;值&gt;</code>\n\n支持的属性:\n• spoiler - 折叠显示 (on/off)\n• provider - AI配置名称\n• prompt - AI提示词 (留空使用全局配置)`,
+              text: `❌ 格式错误\n\n用法: <code>${mainPrefix}sum edit ＜任务ID＞ ＜属性＞ ＜值＞</code>\n\n支持的属性:\n• spoiler - 折叠显示 (on/off)\n• provider - AI配置名称\n• prompt - AI提示词 (留空使用全局配置)`,
               parseMode: "html"
             });
             return;
@@ -1611,7 +1607,7 @@ class SummaryPlugin extends Plugin {
 
             if (!type || !baseUrl || !model) {
               await msg.edit({
-                text: `❌ 格式错误\n\n自定义用法: <code>${mainPrefix}sum config add &lt;名称&gt; &lt;类型&gt; &lt;BaseURL&gt; &lt;Model&gt;</code>\n示例: <code>${mainPrefix}sum config add deepseek openai https://api.deepseek.com deepseek-chat</code>`,
+                text: `❌ 格式错误\n\n自定义用法: <code>${mainPrefix}sum config add ＜名称＞ ＜类型＞ ＜BaseURL＞ ＜Model＞</code>\n示例: <code>${mainPrefix}sum config add deepseek openai https://api.deepseek.com deepseek-chat</code>`,
                 parseMode: "html"
               });
               return;
@@ -1851,4 +1847,3 @@ class SummaryPlugin extends Plugin {
 }
 
 export default new SummaryPlugin();
-

--- a/trace/trace.ts
+++ b/trace/trace.ts
@@ -31,9 +31,9 @@ const help_text = `🎯 <b>自动回应插件 (Trace)</b>
    └ 取消追踪该用户
 
 🔍 <b>关键字追踪</b>
-├ ➕ <code>${mainPrefix}trace kw add &lt;词&gt; 👍👎🥰</code>
+├ ➕ <code>${mainPrefix}trace kw add ＜词＞ 👍👎🥰</code>
 │  └ 添加关键字自动回应
-└ ➖ <code>${mainPrefix}trace kw del &lt;词&gt;</code>
+└ ➖ <code>${mainPrefix}trace kw del ＜词＞</code>
    └ 删除关键字追踪
 
 📊 <b>管理命令</b>

--- a/uai/uai.ts
+++ b/uai/uai.ts
@@ -322,15 +322,15 @@ const getHelpText = () => `⚙️ <b>UAI - 用户消息AI分析</b>
 • <code>${mainPrefix}uai collapse on/off</code> - 开启或关闭 AI 回答折叠
 
 <b>🔌 供应商配置:</b>
-• <code>${mainPrefix}uai add &lt;名称&gt; &lt;url&gt; &lt;key&gt; &lt;type&gt;</code> - 添加供应商
-• <code>${mainPrefix}uai set &lt;名称&gt;</code> - 设置默认供应商
-• <code>${mainPrefix}uai del &lt;名称&gt;</code> - 删除供应商
+• <code>${mainPrefix}uai add ＜名称＞ ＜url＞ ＜key＞ ＜type＞</code> - 添加供应商
+• <code>${mainPrefix}uai set ＜名称＞</code> - 设置默认供应商
+• <code>${mainPrefix}uai del ＜名称＞</code> - 删除供应商
 • <code>${mainPrefix}uai list</code> - 列出所有供应商
-• <code>${mainPrefix}uai model &lt;名称&gt; &lt;模型&gt;</code> - 修改模型
+• <code>${mainPrefix}uai model ＜名称＞ ＜模型＞</code> - 修改模型
 
 <b>📝 提示词配置:</b>
-• <code>${mainPrefix}uai prompt add &lt;名称&gt; &lt;内容&gt;</code> - 添加自定义提示词
-• <code>${mainPrefix}uai prompt del &lt;名称&gt;</code> - 删除自定义提示词
+• <code>${mainPrefix}uai prompt add ＜名称＞ ＜内容＞</code> - 添加自定义提示词
+• <code>${mainPrefix}uai prompt del ＜名称＞</code> - 删除自定义提示词
 • <code>${mainPrefix}uai prompt list</code> - 列出所有提示词
 
 <b>💡 内置提示词:</b>

--- a/warp/warp.ts
+++ b/warp/warp.ts
@@ -483,7 +483,7 @@ const helpText = `⚡ <b>WARP 管理面板</b>
 <code>${mainPrefix}warp status</code> - 查看 WARP 综合状态
 <code>${mainPrefix}warp y</code> - 切换 WireProxy 开/关
 <code>${mainPrefix}warp ip</code> - 重启 WireProxy (更换 WARP IP)
-<code>${mainPrefix}warp port &lt;端口&gt;</code> - 修改 WireProxy 监听端口
+<code>${mainPrefix}warp port ＜端口＞</code> - 修改 WireProxy 监听端口
 <code>${mainPrefix}warp proxy</code> - 配置 Telegram 代理设置 (需要 WireProxy 运行)
 <code>${mainPrefix}warp unproxy</code> - 关闭 Telegram 代理设置
 <code>${mainPrefix}warp music</code> - 配置 Music 插件代理设置
@@ -525,7 +525,7 @@ class WarpPlugin extends Plugin {
         text = `📖 <b>重启/换IP</b>\n\n<code>${cmd} ip</code> - 重启 wireproxy 以更换 IP`;
         break;
       case "port":
-        text = `📖 <b>端口</b>\n\n<code>${cmd} port &lt;端口&gt;</code> - 修改监听端口并重启`;
+        text = `📖 <b>端口</b>\n\n<code>${cmd} port ＜端口＞</code> - 修改监听端口并重启`;
         break;
       case "uninstall":
       case "uninstall_all":

--- a/weather/weather.ts
+++ b/weather/weather.ts
@@ -115,7 +115,7 @@ const help_text = `🌤️ <b>天气查询插件</b>
 • 🆓 <b>完全免费</b>：使用 Open-Meteo 免费API
 
 <b>🔧 使用方法:</b>
-• <code>${mainPrefix}weather &lt;城市名&gt;</code> - 查询指定城市天气
+• <code>${mainPrefix}weather ＜城市名＞</code> - 查询指定城市天气
 
 <b>💡 使用示例:</b>
 • <code>${mainPrefix}weather 北京</code> - 查询北京天气

--- a/whois/whois.ts
+++ b/whois/whois.ts
@@ -36,9 +36,9 @@ const help_text = `🔍 <b>WHOIS 域名查询</b>
 • 域名到期提醒
 
 <b>🔧 使用：</b>
-• <code>${mainPrefix}whois &lt;域名&gt;</code> - 查询指定域名
+• <code>${mainPrefix}whois ＜域名＞</code> - 查询指定域名
 • <code>${mainPrefix}whois</code> - 回复包含域名的消息
-• <code>${mainPrefix}whois batch &lt;域名1&gt; &lt;域名2&gt;...</code> - 批量查询
+• <code>${mainPrefix}whois batch ＜域名1＞ ＜域名2＞...</code> - 批量查询
 • <code>${mainPrefix}whois history</code> - 查看查询历史
 • <code>${mainPrefix}whois clear</code> - 清除历史记录
 
@@ -532,7 +532,7 @@ class WhoisPlugin extends Plugin {
     const history = this.db.data.history;
     if (history.length === 0) {
       await msg.edit({
-        text: `📭 <b>暂无查询历史</b>\n\n💡 使用 <code>${mainPrefix}whois &lt;域名&gt;</code> 开始查询`,
+        text: `📭 <b>暂无查询历史</b>\n\n💡 使用 <code>${mainPrefix}whois ＜域名＞</code> 开始查询`,
         parseMode: "html"
       });
       return;


### PR DESCRIPTION
## Summary
- normalize Telegram-facing placeholder text across plugin help, prompt, and description output
- convert unstable entity/raw-angle placeholder forms to stable full-width visible markers
- preserve one-file-per-commit history for easier review and selective cherry-picking

## Notes
- delivered as separate single-file commits on branch `entity-text-fixes`
- `pmcaptcha` was not included because no local source file existed in this workspace during delivery