### PR TITLE
fix(whois): 修复 SSE 流式响应解析，解决所有域名查询失败

### DIFF
--- a/whois/whois.ts
+++ b/whois/whois.ts
@@ -23,6 +23,31 @@ const htmlEscape = (text: string): string =>
     '"': '&quot;', "'": '&#x27;' 
   }[m] || m));
 
+// 解析 namebeta.com 的 SSE 流式响应，返回各事件对象
+function parseSSEResponse(raw: string): Array<{type: string; data: any}> {
+  const events: Array<{type: string; data: any}> = [];
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('data: ')) continue;
+    try {
+      const json = JSON.parse(trimmed.slice(6));
+      events.push(json);
+    } catch { /* skip malformed lines */ }
+  }
+  return events;
+}
+
+// 从 SSE 事件列表中提取 whois 原始文本
+function extractWhoisFromSSE(raw: string): string | null {
+  const events = parseSSEResponse(raw);
+  for (const evt of events) {
+    if (evt.type === 'check' && evt.data?.whois?.whois) {
+      return evt.data.whois.whois;
+    }
+  }
+  return null;
+}
+
 const prefixes = getPrefixes();
 const mainPrefix = prefixes[0];
 
@@ -225,17 +250,18 @@ class WhoisPlugin extends Plugin {
         parseMode: "html"
       });
       
-      // 使用 axios 进行请求
-      const response = await axios.get(`https://namebeta.com/api/search/check`, {
+      // namebeta.com 返回 SSE 流式响应，需获取原始文本并解析
+      const apiResponse = await axios.get<string>(`https://namebeta.com/api/search/check`, {
         params: { query: domain },
         timeout: 10000,
         headers: {
           'User-Agent': 'TeleBox/1.0'
-        }
+        },
+        responseType: 'text'
       });
       
-      if (response.status === 200 && response.data) {
-        const whoisData = response.data.whois?.whois;
+      if (apiResponse.status === 200 && apiResponse.data) {
+        const whoisData = extractWhoisFromSSE(apiResponse.data);
         
         if (!whoisData) {
           await msg.edit({
@@ -292,7 +318,7 @@ class WhoisPlugin extends Plugin {
         
       } else {
         await msg.edit({
-          text: `❌ <b>API 服务器错误</b>\n\n<b>状态码：</b> ${response.status}\n\n💡 请稍后重试`,
+          text: `❌ <b>API 服务器错误</b>\n\n<b>状态码：</b> ${apiResponse.status}\n\n💡 请稍后重试`,
           parseMode: "html"
         });
       }
@@ -474,24 +500,31 @@ class WhoisPlugin extends Plugin {
         }
         
         // 查询域名
-        const response = await axios.get(`https://namebeta.com/api/search/check`, {
+        const batchResponse = await axios.get<string>(`https://namebeta.com/api/search/check`, {
           params: { query: domain },
-          timeout: 5000,
-          headers: { 'User-Agent': 'TeleBox/1.0' }
+          timeout: 10000,
+          headers: { 'User-Agent': 'TeleBox/1.0' },
+          responseType: 'text'
         });
         
-        if (response.status === 200 && response.data?.whois?.whois) {
-          results.push(`✅ <code>${htmlEscape(domain)}</code>`);
-          successCount++;
+        if (batchResponse.status === 200 && batchResponse.data) {
+          const whoisData = extractWhoisFromSSE(batchResponse.data);
           
-          // 保存到缓存
-          const whoisData = response.data.whois.whois;
-          const record: WhoisRecord = {
-            domain,
-            rawData: whoisData,
-            queryTime: new Date().toISOString()
-          };
-          await this.saveWhoisRecord(record);
+          if (whoisData) {
+            results.push(`✅ <code>${htmlEscape(domain)}</code>`);
+            successCount++;
+            
+            // 保存到缓存
+            const record: WhoisRecord = {
+              domain,
+              rawData: whoisData,
+              queryTime: new Date().toISOString()
+            };
+            await this.saveWhoisRecord(record);
+          } else {
+            results.push(`❌ <code>${htmlEscape(domain)}</code> - 查询失败`);
+            failCount++;
+          }
         } else {
           results.push(`❌ <code>${htmlEscape(domain)}</code> - 查询失败`);
           failCount++;


### PR DESCRIPTION
## 问题

namebeta.com API 返回的是 **Server-Sent Events (SSE)** 流式格式（每行以 `data: ` 开头接 JSON），但原代码直接用 axios GET 将整个响应当作普通 JSON 对象处理。这导致 `response.data` 是原始字符串，访问 `.whois?.whois` 永远返回 `undefined`，所有域名查询都会走到"查询失败"分支。

## 修复内容

- 新增 `parseSSEResponse()` — 逐行解析 `data: ` 前缀的 SSE 事件，提取 JSON 对象
- 新增 `extractWhoisFromSSE()` — 从解析后的事件列表中找到 `type === "check"` 的事件，返回 `data.whois.whois`
- 所有 axios 请求添加 `responseType: "text"` 确保获取原始文本
- 修正数据路径：WHOIS 数据实际在 `check` 事件的 `data.whois.whois` 中，而非 `response.data.whois?.whois`
- 单查和批量查两个入口同步修复

## 测试

实测 `voidtools.com` 等域名查询均能正常返回完整 WHOIS 信息。

---

> **Note:** 此修复由 AI (Ava / OpenClaw) 编写、测试并提交。