### PR TITLE
feat(codex_image): 在说明文字中，对提示词使用可展开的折叠块

### DIFF
--- a/codex_image/codex_image.ts
+++ b/codex_image/codex_image.ts
@@ -48,6 +48,9 @@ const htmlEscape = (input: string): string =>
       })[ch] || ch,
   );
 
+const expandableBlock = (input: string): string =>
+  `<blockquote expandable>${htmlEscape(input)}</blockquote>`;
+
 async function getDb(): Promise<Low<CodexImageConfig>> {
   if (!dbPromise) {
     dbPromise = JSONFilePreset<CodexImageConfig>(configPath, {
@@ -452,10 +455,10 @@ async function handleCximg(msg: Api.Message): Promise<void> {
     imageBuffer,
   );
   const caption = [
-    `<b>提示词:</b> ${htmlEscape(prompt)}`,
+    `<b>提示词:</b>\n${expandableBlock(prompt)}`,
     `<b>耗时:</b> ${htmlEscape(elapsed)}`,
     result.revisedPrompt
-      ? `<b>修订提示词:</b> ${htmlEscape(result.revisedPrompt)}`
+      ? `<b>修订提示词:</b>\n${expandableBlock(result.revisedPrompt)}`
       : "",
   ]
     .filter(Boolean)


### PR DESCRIPTION
## Summary

将图片生成结果中的提示词和修订提示词改为 Telegram 折叠块（`<blockquote expandable>`）格式，避免长提示词导致消息过长溢出。

## Changes

- 新增 `expandableBlock()` 辅助函数，将文本包裹在 `<blockquote expandable>` 标签中
- caption 中的提示词和修订提示词改用折叠块展示，标签后换行，块内容可展开查看

## Before

```
<b>提示词:</b> 一段很长很长的提示词内容...
<b>修订提示词:</b> 一段更长更长的修订提示词内容...
```

提示词直接内联显示，长文本会导致消息超出 Telegram 长度限制。

## After

```
<b>提示词:</b>
<blockquote expandable>一段很长很长的提示词内容...</blockquote>
<b>修订提示词:</b>
<blockquote expandable>一段更长更长的修订提示词内容...</blockquote>
```

默认折叠，点击可展开，不影响阅读体验。

---

> **Note:** 此插件由 AI (Ava / OpenClaw) 编写并提交。