### PR TITLE
feat：新增随机时间签到功能，并优化命令与配置说明

### DIFF
--- a/checkin/checkin.ts
+++ b/checkin/checkin.ts
@@ -19,24 +19,28 @@ interface SignTarget {
 
 interface CheckInConfig {
   runTime: string;
+  runTimeEnd?: string;
   logChat: string;
   randomDelay: number;
   lastRunDate: string;
   botToken: string;
   pushChatId: string;
   targets: SignTarget[];
+  currentRunTime?: string;
 }
 
 type SignResult = { success: boolean; message?: string; error?: string };
 
 const DEFAULT_CONFIG: CheckInConfig = {
   runTime: "10:00",
+  runTimeEnd: "11:30",
   logChat: "",
   randomDelay: 0,
   lastRunDate: "",
   botToken: "",
   pushChatId: "",
   targets: [],
+  currentRunTime: undefined,
 };
 
 const SH_TZ = "Asia/Shanghai";
@@ -84,6 +88,7 @@ class CheckInPlugin extends Plugin {
   private readonly cfg = new ConfigManager();
   private timer: NodeJS.Timeout | null = null;
   private running = false;
+  private todayRunTime: string | null = null;
 
   constructor() {
     super();
@@ -103,11 +108,7 @@ class CheckInPlugin extends Plugin {
         const action = (args[0] || "").toLowerCase();
 
         if (!action || action === "help" || action === "h") {
-          if (!action) {
-            if (!this.cfg.get().targets.length) {
-              await this.edit(msg, "❌ 当前没有配置签到目标，请先使用 add");
-              return;
-            }
+          if (!action && this.cfg.get().targets.length > 0) {
             await this.edit(msg, "🚀 开始执行所有签到任务...");
             void this.runAllSigns("手动触发", msg.chatId, msg);
             return;
@@ -116,122 +117,20 @@ class CheckInPlugin extends Plugin {
           return;
         }
 
-        if (action === "add") {
-          const id = args[1];
-          const name = args[2];
-          const target = args[3];
-          const command = args[4];
-          if (!id || !name || !target || !command) {
-            await this.edit(msg, `❌ 格式错误：${PREFIX}qd add [ID] [名称] [目标] [命令] [data:回调数据|text:按钮名]`);
-            return;
-          }
-
-          const matcher = this.parseButtonMatcher(args.slice(5));
-          const conf = this.cfg.get();
-          const next: SignTarget = { id, name, target, command, ...matcher, enabled: true };
-          const i = conf.targets.findIndex((t) => t.id === id);
-          if (i >= 0) conf.targets[i] = next;
-          else conf.targets.push(next);
-          this.cfg.save({ targets: conf.targets });
-          await this.edit(msg, `✅ 已${i >= 0 ? "更新" : "添加"}签到目标: ${name} (${id})`);
+        if (["add", "del", "delete", "list", "toggle", "test"].includes(action)) {
+          await this.handleTargetCommand(action, args, msg);
           return;
         }
 
-        if (action === "del" || action === "delete") {
-          const id = args[1];
-          if (!id) return void (await this.edit(msg, `❌ 请指定目标ID：${PREFIX}qd del [ID]`));
-          const conf = this.cfg.get();
-          const n = conf.targets.length;
-          conf.targets = conf.targets.filter((t) => t.id !== id);
-          this.cfg.save({ targets: conf.targets });
-          await this.edit(msg, conf.targets.length < n ? `✅ 已删除签到目标: ${id}` : `❌ 未找到目标: ${id}`);
-          return;
-        }
-
-        if (action === "list") {
-          const conf = this.cfg.get();
-          if (!conf.targets.length) return void (await this.edit(msg, "📝 当前没有配置签到目标"));
-          const enabled = conf.targets.filter((t) => t.enabled).length;
-          const lines = conf.targets
-            .map((t, i) => {
-              const m = t.callbackData ? `\n   回调: ${this.escape(t.callbackData)}` : t.buttonText ? `\n   按钮: ${this.escape(t.buttonText)}` : "";
-              return `${t.enabled ? "🟢" : "🔴"} <b>${i + 1}. ${this.escape(t.name)}</b>\n   ID: ${this.escape(t.id)}\n   目标: ${this.escape(t.target)}\n   命令: ${this.escape(t.command)}${m}`;
-            })
-            .join("\n\n");
-          await this.edit(msg, `📝 <b>签到目标列表</b> (${enabled}/${conf.targets.length} 个启用)\n\n${lines}`);
-          return;
-        }
-
-        if (action === "toggle") {
-          const id = args[1];
-          if (!id) return void (await this.edit(msg, `❌ 请指定目标ID：${PREFIX}qd toggle [ID]`));
-          const conf = this.cfg.get();
-          const t = conf.targets.find((x) => x.id === id);
-          if (!t) return void (await this.edit(msg, `❌ 未找到目标: ${id}`));
-          t.enabled = !t.enabled;
-          this.cfg.save({ targets: conf.targets });
-          await this.edit(msg, `✅ 已${t.enabled ? "启用" : "禁用"}签到目标: ${this.escape(t.name)} (${this.escape(id)})`);
-          return;
-        }
-
-        if (action === "test") {
-          const id = args[1];
-          if (!id) return void (await this.edit(msg, `❌ 请指定目标ID：${PREFIX}qd test [ID]`));
-          const t = this.cfg.get().targets.find((x) => x.id === id);
-          if (!t) return void (await this.edit(msg, `❌ 未找到目标: ${id}`));
-          await this.edit(msg, `🚀 开始测试签到目标: ${this.escape(t.name)}...`);
-          const r = await this.runSingleSign(t);
-          await this.edit(msg, r.success ? `✅ <b>${this.escape(t.name)}</b> 测试成功\n\n结果: ${this.escape(r.message || "无")}` : `❌ <b>${this.escape(t.name)}</b> 测试失败\n\n错误: ${this.escape(r.error || "未知错误")}`);
-          return;
-        }
-
-        if (action === "set") {
-          const type = (args[1] || "").toLowerCase();
-          const v = args[2];
-          if (type === "time") {
-            if (!v || !/^([01]?\d|2[0-3]):[0-5]\d$/.test(v)) return void (await this.edit(msg, "❌ 格式错误，请使用 HH:MM (例如 10:30)"));
-            this.cfg.save({ runTime: v });
-            await this.edit(msg, `✅ 每日运行时间已设置为: ${v}`);
-            return;
-          }
-          if (type === "bot") {
-            const token = args[2];
-            const chatId = args[3];
-            if (!token || !chatId) return void (await this.edit(msg, `❌ 格式错误：${PREFIX}qd set bot [Token] [ChatID]`));
-            this.cfg.save({ botToken: token, pushChatId: chatId });
-            await this.edit(msg, `✅ Bot配置已更新:\nToken: ${this.mask(token)}\nChatID: ${this.escape(chatId)}`);
-            return;
-          }
-          if (type === "delay") {
-            const n = Number(v);
-            if (!Number.isInteger(n) || n < 0 || n > 60) return void (await this.edit(msg, "❌ 请输入 0-60 之间的分钟数"));
-            this.cfg.save({ randomDelay: n });
-            await this.edit(msg, `✅ 随机延迟已设置为: ${n} 分钟`);
-            return;
-          }
-          await this.edit(msg, "❌ 未知设置项。支持: time, bot, delay");
+        if (["set", "config", "settings", "info"].includes(action)) {
+          await this.handleConfigCommand(action, args, msg);
           return;
         }
 
         if (action === "reset") {
-          this.cfg.save({ lastRunDate: "" });
+          this.cfg.save({ lastRunDate: "", currentRunTime: undefined });
+          this.todayRunTime = null;
           await this.edit(msg, "✅ 已重置每日运行状态，定时任务可再次触发。");
-          return;
-        }
-
-        if (action === "settings") {
-          const conf = this.cfg.get();
-          const enabled = conf.targets.filter((t) => t.enabled).length;
-          await this.edit(
-            msg,
-            `⚙️ <b>CheckIn 配置信息</b>\n\n` +
-              `运行时间: ${this.escape(conf.runTime)}\n` +
-              `Bot Token: ${this.mask(conf.botToken) || "未设置"}\n` +
-              `推送目标: ${this.escape(conf.pushChatId || "未设置")}\n` +
-              `随机延迟: ${conf.randomDelay} 分钟\n` +
-              `上次运行: ${this.escape(conf.lastRunDate || "无")}\n` +
-              `签到目标: ${enabled}/${conf.targets.length} 个启用`
-          );
           return;
         }
 
@@ -245,17 +144,213 @@ class CheckInPlugin extends Plugin {
     },
   };
 
+  private async handleTargetCommand(action: string, args: string[], msg: Api.Message): Promise<void> {
+    const conf = this.cfg.get();
+
+    if (action === "add") {
+      const id = args[1];
+      const name = args[2];
+      const target = args[3];
+      const command = args[4];
+      if (!id || !name || !target || !command) {
+        await this.edit(msg, `❌ 格式错误：${PREFIX}qd add [ID] [名称] [目标] [命令] [data:回调数据|text:按钮名]`);
+        return;
+      }
+
+      const matcher = this.parseButtonMatcher(args.slice(5));
+      const next: SignTarget = { id, name, target, command, ...matcher, enabled: true };
+      const i = conf.targets.findIndex((t) => t.id === id);
+      if (i >= 0) conf.targets[i] = next;
+      else conf.targets.push(next);
+      this.cfg.save({ targets: conf.targets });
+      await this.edit(msg, `✅ 已${i >= 0 ? "更新" : "添加"}签到目标: ${name} (${id})`);
+      return;
+    }
+
+    if (action === "del" || action === "delete") {
+      const id = args[1];
+      if (!id) return void (await this.edit(msg, `❌ 请指定目标ID：${PREFIX}qd del [ID]`));
+      const n = conf.targets.length;
+      conf.targets = conf.targets.filter((t) => t.id !== id);
+      this.cfg.save({ targets: conf.targets });
+      await this.edit(msg, conf.targets.length < n ? `✅ 已删除签到目标: ${id}` : `❌ 未找到目标: ${id}`);
+      return;
+    }
+
+    if (action === "list") {
+      if (!conf.targets.length) return void (await this.edit(msg, "📝 当前没有配置签到目标"));
+      const enabled = conf.targets.filter((t) => t.enabled).length;
+      const lines = conf.targets
+        .map((t, i) => {
+          const m = t.callbackData ? `\n   回调: ${this.escape(t.callbackData)}` : t.buttonText ? `\n   按钮: ${this.escape(t.buttonText)}` : "";
+          return `${t.enabled ? "🟢" : "🔴"} <b>${i + 1}. ${this.escape(t.name)}</b>\n   ID: ${this.escape(t.id)}\n   目标: ${this.escape(t.target)}\n   命令: ${this.escape(t.command)}${m}`;
+        })
+        .join("\n\n");
+      await this.edit(msg, `📝 <b>签到目标列表</b> (${enabled}/${conf.targets.length} 个启用)\n\n${lines}`);
+      return;
+    }
+
+    if (action === "toggle") {
+      const id = args[1];
+      if (!id) return void (await this.edit(msg, `❌ 请指定目标ID：${PREFIX}qd toggle [ID]`));
+      const t = conf.targets.find((x) => x.id === id);
+      if (!t) return void (await this.edit(msg, `❌ 未找到目标: ${id}`));
+      t.enabled = !t.enabled;
+      this.cfg.save({ targets: conf.targets });
+      await this.edit(msg, `✅ 已${t.enabled ? "启用" : "禁用"}签到目标: ${this.escape(t.name)} (${this.escape(id)})`);
+      return;
+    }
+
+    if (action === "test") {
+      const id = args[1];
+      if (!id) return void (await this.edit(msg, `❌ 请指定目标ID：${PREFIX}qd test [ID]`));
+      const t = conf.targets.find((x) => x.id === id);
+      if (!t) return void (await this.edit(msg, `❌ 未找到目标: ${id}`));
+      await this.edit(msg, `🚀 开始测试签到目标: ${this.escape(t.name)}...`);
+      const r = await this.runSingleSign(t);
+      await this.edit(msg, r.success ? `✅ <b>${this.escape(t.name)}</b> 测试成功\n\n结果: ${this.escape(r.message || "无")}` : `❌ <b>${this.escape(t.name)}</b> 测试失败\n\n错误: ${this.escape(r.error || "未知错误")}`);
+      return;
+    }
+  }
+
+  private async handleConfigCommand(action: string, args: string[], msg: Api.Message): Promise<void> {
+    const conf = this.cfg.get();
+
+    if (action === "settings" || action === "config" || action === "info") {
+      const enabled = conf.targets.filter((t) => t.enabled).length;
+      const timeRange = conf.runTimeEnd ? `${conf.runTime} ~ ${conf.runTimeEnd}` : conf.runTime;
+      const timeMode = conf.runTimeEnd ? "🔄 随机时间模式" : "📌 固定时间模式";
+      
+      await this.edit(
+        msg,
+        `⚙️ <b>CheckIn 配置信息</b>\n\n` +
+          `${timeMode}\n` +
+          `⏰ 运行时间: ${this.escape(timeRange)}\n` +
+          `🎲 随机延迟: ${conf.randomDelay} 分钟\n` +
+          `🤖 Bot推送: ${conf.botToken ? "已配置" : "未配置"}\n` +
+          `📱 推送目标: ${this.escape(conf.pushChatId || "未设置")}\n` +
+          `📅 上次运行: ${this.escape(conf.lastRunDate || "无")}\n` +
+          `🎯 签到目标: ${enabled}/${conf.targets.length} 个启用`
+      );
+      return;
+    }
+
+    if (action === "set" || action === "config") {
+      const type = (args[1] || "").toLowerCase();
+      const value = args[2];
+      const extra = args[3];
+
+      if (type === "time" || type === "t") {
+        if (!value || !/^([01]?\d|2[0-3]):[0-5]\d$/.test(value)) {
+          await this.edit(msg, "❌ 格式错误，请使用 HH:MM (例如 10:30)");
+          return;
+        }
+        
+        if (conf.runTimeEnd) {
+          const [startH, startM] = value.split(":").map(Number);
+          const [endH, endM] = conf.runTimeEnd.split(":").map(Number);
+          if (startH * 60 + startM > endH * 60 + endM && endH * 60 + endM > 0) {
+            await this.edit(msg, `⚠️ 开始时间 (${value}) 晚于结束时间 (${conf.runTimeEnd})，请调整时间范围`);
+            return;
+          }
+        }
+        
+        this.cfg.save({ runTime: value });
+        await this.edit(msg, `✅ 开始时间已设置为: ${value}`);
+        return;
+      }
+
+      if (type === "range" || type === "r") {
+        if (!value) {
+          this.cfg.save({ runTimeEnd: undefined });
+          await this.edit(msg, "✅ 已清除随机时间窗口，使用固定时间模式");
+          return;
+        }
+        
+        if (!/^([01]?\d|2[0-3]):[0-5]\d$/.test(value)) {
+          await this.edit(msg, "❌ 格式错误，请使用 HH:MM (例如 11:30)");
+          return;
+        }
+        
+        const [startH, startM] = conf.runTime.split(":").map(Number);
+        const [endH, endM] = value.split(":").map(Number);
+        if (startH * 60 + startM > endH * 60 + endM && endH * 60 + endM > 0) {
+          await this.edit(msg, `⚠️ 开始时间 (${conf.runTime}) 晚于结束时间 (${value})，将允许跨天执行`);
+        }
+        
+        this.cfg.save({ runTimeEnd: value });
+        await this.edit(msg, `✅ 随机时间窗口已设置为: ${conf.runTime} ~ ${value}`);
+        return;
+      }
+
+      if (type === "delay" || type === "d") {
+        const n = Number(value);
+        if (!Number.isInteger(n) || n < 0 || n > 60) {
+          await this.edit(msg, "❌ 请输入 0-60 之间的分钟数");
+          return;
+        }
+        this.cfg.save({ randomDelay: n });
+        await this.edit(msg, `✅ 随机延迟已设置为: ${n} 分钟`);
+        return;
+      }
+
+      if (type === "bot" || type === "b") {
+        if (!value || !extra) {
+          await this.edit(msg, `❌ 格式错误：${PREFIX}qd set bot [Token] [ChatID]`);
+          return;
+        }
+        this.cfg.save({ botToken: value, pushChatId: extra });
+        await this.edit(msg, `✅ Bot配置已更新:\nToken: ${this.mask(value)}\nChatID: ${this.escape(extra)}`);
+        return;
+      }
+
+      if (type === "log" || type === "l") {
+        if (!value) {
+          await this.edit(msg, `❌ 请指定日志聊天ID：${PREFIX}qd set log [ChatID]`);
+          return;
+        }
+        this.cfg.save({ logChat: value });
+        await this.edit(msg, `✅ 日志聊天已设置为: ${this.escape(value)}`);
+        return;
+      }
+
+      await this.edit(msg, `❌ 未知设置项。支持: time, range, delay, bot, log`);
+      return;
+    }
+  }
+
   private async checkAndRun(): Promise<void> {
     if (this.running) return;
     try {
       const conf = this.cfg.get();
       const now = new Date();
       const today = this.dateCN(now);
-      const [h, m] = conf.runTime.split(":").map(Number);
       const t = new Date(now.toLocaleString("en-US", { timeZone: SH_TZ }));
-      if (conf.lastRunDate === today || t.getHours() !== h || t.getMinutes() !== m) return;
+      
+      if (conf.lastRunDate === today) return;
+
+      const runTimeToday = this.getTodayRunTime();
+      if (!runTimeToday) {
+        this.todayRunTime = conf.runTime;
+      } else {
+        this.todayRunTime = runTimeToday;
+      }
+
+      const [h, m] = this.todayRunTime.split(":").map(Number);
+      
+      if (t.getHours() !== h || t.getMinutes() !== m) return;
+
+      if (conf.runTimeEnd) {
+        const [endH, endM] = conf.runTimeEnd.split(":").map(Number);
+        const endMinutes = endH * 60 + endM;
+        const currentMinutes = t.getHours() * 60 + t.getMinutes();
+        if (currentMinutes > endMinutes) return;
+      }
+
       this.running = true;
-      if (conf.randomDelay > 0) await this.sleep(Math.floor(Math.random() * conf.randomDelay * 60_000));
+      if (conf.randomDelay > 0) {
+        await this.sleep(Math.floor(Math.random() * conf.randomDelay * 60_000));
+      }
       await this.runAllSigns("自动定时任务");
       this.cfg.save({ lastRunDate: today });
     } catch (e) {
@@ -263,6 +358,33 @@ class CheckInPlugin extends Plugin {
     } finally {
       this.running = false;
     }
+  }
+
+  private getTodayRunTime(): string | null {
+    const conf = this.cfg.get();
+    if (!conf.runTimeEnd) return null;
+    if (this.todayRunTime) return this.todayRunTime;
+
+    const [startH, startM] = conf.runTime.split(":").map(Number);
+    const [endH, endM] = conf.runTimeEnd.split(":").map(Number);
+    
+    const startMinutes = startH * 60 + startM;
+    let endMinutes = endH * 60 + endM;
+    
+    if (endMinutes < startMinutes) {
+      endMinutes += 24 * 60;
+    }
+    
+    if (endMinutes <= startMinutes) {
+      return conf.runTime;
+    }
+    
+    const randomMinute = startMinutes + Math.floor(Math.random() * (endMinutes - startMinutes));
+    const finalMinutes = randomMinute >= 24 * 60 ? randomMinute - 24 * 60 : randomMinute;
+    const hours = Math.floor(finalMinutes / 60);
+    const minutes = finalMinutes % 60;
+    
+    return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
   }
 
   private async runAllSigns(source: string, fallbackPeer?: any, statusMsg?: Api.Message): Promise<void> {
@@ -403,29 +525,37 @@ class CheckInPlugin extends Plugin {
   }
 
   private helpText(): string {
-    return `<b>CheckIn 自动化签到插件</b>
+    return `<b>🤖 CheckIn 自动化签到插件</b>
 
-<b>基础指令：</b>
+<b>📌 基础指令：</b>
 <code>${PREFIX}qd</code> - 手动触发所有签到
 <code>${PREFIX}qd reset</code> - 重置今日运行状态
-<code>${PREFIX}qd settings</code> - 查看当前配置
+<code>${PREFIX}qd help</code> - 显示此帮助
 
-<b>目标管理：</b>
-<code>${PREFIX}qd add [ID] [名称] [目标] [命令]</code>
-<code>${PREFIX}qd add [ID] [名称] [目标] [命令] data:[回调数据]</code>（推荐）
-<code>${PREFIX}qd add [ID] [名称] [目标] [命令] text:[按钮名]</code>
+<b>🎯 目标管理：</b>
+<code>${PREFIX}qd add [ID] [名称] [目标] [命令] [data:回调|text:按钮]</code>
 <code>${PREFIX}qd del [ID]</code>
 <code>${PREFIX}qd list</code>
 <code>${PREFIX}qd toggle [ID]</code>
 <code>${PREFIX}qd test [ID]</code>
 
-<b>设置：</b>
-<code>${PREFIX}qd set time [HH:MM]</code>
-<code>${PREFIX}qd set bot [Token] [ChatID]</code>
-<code>${PREFIX}qd set delay [分钟]</code>
+<b>⚙️ 配置管理：</b>
+<code>${PREFIX}qd set time [HH:MM]</code> - 设置开始时间
+<code>${PREFIX}qd set range [HH:MM]</code> - 设置随机窗口结束时间（取消则清除）
+<code>${PREFIX}qd set delay [分钟]</code> - 随机延迟 0-60分钟
+<code>${PREFIX}qd set bot [Token] [ChatID]</code> - 设置Bot推送
+<code>${PREFIX}qd set log [ChatID]</code> - 设置日志聊天
+<code>${PREFIX}qd settings</code> - 查看当前配置
 
-<b>示例：</b>
-<code>${PREFIX}qd add storm Storm签到 @stormuser_bot /start data:checkin</code>`;
+<b>💡 使用示例：</b>
+<code>${PREFIX}qd add storm Storm签到 @storm_bot /start data:checkin</code>
+<code>${PREFIX}qd set time 10:00</code> - 从10点开始
+<code>${PREFIX}qd set range 11:30</code> - 到11:30结束（随机时间模式）
+<code>${PREFIX}qd set range</code> - 清除随机窗口（固定时间模式）
+
+<b>🔄 随机时间说明：</b>
+设置 range 后，每天在 time ~ range 之间随机选择时间执行，
+避免固定时间被检测。支持跨天（如 22:00 ~ 02:00）。`;
   }
 
   private async edit(msg: Api.Message, text: string): Promise<void> {

--- a/checkin/checkin.ts
+++ b/checkin/checkin.ts
@@ -219,18 +219,18 @@ class CheckInPlugin extends Plugin {
     if (action === "settings" || action === "config" || action === "info") {
       const enabled = conf.targets.filter((t) => t.enabled).length;
       const timeRange = conf.runTimeEnd ? `${conf.runTime} ~ ${conf.runTimeEnd}` : conf.runTime;
-      const timeMode = conf.runTimeEnd ? "🔄 随机时间模式" : "📌 固定时间模式";
-      
+      const timeMode = conf.runTimeEnd ? "🔄 在设定时间段内随机执行" : "📌 按固定时间执行";
+
       await this.edit(
         msg,
         `⚙️ <b>CheckIn 配置信息</b>\n\n` +
           `${timeMode}\n` +
-          `⏰ 运行时间: ${this.escape(timeRange)}\n` +
-          `🎲 随机延迟: ${conf.randomDelay} 分钟\n` +
-          `🤖 Bot推送: ${conf.botToken ? "已配置" : "未配置"}\n` +
-          `📱 推送目标: ${this.escape(conf.pushChatId || "未设置")}\n` +
-          `📅 上次运行: ${this.escape(conf.lastRunDate || "无")}\n` +
-          `🎯 签到目标: ${enabled}/${conf.targets.length} 个启用`
+          `⏰ 执行时间: ${this.escape(timeRange)}\n` +
+          `🎲 额外随机延迟: ${conf.randomDelay} 分钟\n` +
+          `🤖 Bot 通知: ${conf.botToken ? "已配置" : "未配置"}\n` +
+          `📱 通知目标: ${this.escape(conf.pushChatId || "未设置")}\n` +
+          `📅 最近执行日期: ${this.escape(conf.lastRunDate || "无")}\n` +
+          `🎯 已启用目标: ${enabled}/${conf.targets.length}`
       );
       return;
     }
@@ -263,7 +263,7 @@ class CheckInPlugin extends Plugin {
       if (type === "range" || type === "r") {
         if (!value) {
           this.cfg.save({ runTimeEnd: undefined });
-          await this.edit(msg, "✅ 已清除随机时间窗口，使用固定时间模式");
+          await this.edit(msg, "✅ 已清除执行时间范围，改为固定时间执行");
           return;
         }
         
@@ -279,7 +279,7 @@ class CheckInPlugin extends Plugin {
         }
         
         this.cfg.save({ runTimeEnd: value });
-        await this.edit(msg, `✅ 随机时间窗口已设置为: ${conf.runTime} ~ ${value}`);
+        await this.edit(msg, `✅ 执行时间范围已设置为: ${conf.runTime} ~ ${value}（将在该时间段内随机执行）`);
         return;
       }
 
@@ -541,21 +541,21 @@ class CheckInPlugin extends Plugin {
 
 <b>⚙️ 配置管理：</b>
 <code>${PREFIX}qd set time [HH:MM]</code> - 设置开始时间
-<code>${PREFIX}qd set range [HH:MM]</code> - 设置随机窗口结束时间（取消则清除）
-<code>${PREFIX}qd set delay [分钟]</code> - 随机延迟 0-60分钟
-<code>${PREFIX}qd set bot [Token] [ChatID]</code> - 设置Bot推送
+<code>${PREFIX}qd set range [HH:MM]</code> - 设置执行时间结束点（留空则改为固定时间）
+<code>${PREFIX}qd set delay [分钟]</code> - 设置额外随机延迟（0-60 分钟）
+<code>${PREFIX}qd set bot [Token] [ChatID]</code> - 设置 Bot 通知
 <code>${PREFIX}qd set log [ChatID]</code> - 设置日志聊天
 <code>${PREFIX}qd settings</code> - 查看当前配置
 
 <b>💡 使用示例：</b>
 <code>${PREFIX}qd add storm Storm签到 @storm_bot /start data:checkin</code>
-<code>${PREFIX}qd set time 10:00</code> - 从10点开始
-<code>${PREFIX}qd set range 11:30</code> - 到11:30结束（随机时间模式）
-<code>${PREFIX}qd set range</code> - 清除随机窗口（固定时间模式）
+<code>${PREFIX}qd set time 10:00</code> - 从 10:00 开始
+<code>${PREFIX}qd set range 11:30</code> - 在 10:00 到 11:30 之间随机执行
+<code>${PREFIX}qd set range</code> - 清除时间范围，改为固定时间执行
 
-<b>🔄 随机时间说明：</b>
-设置 range 后，每天在 time ~ range 之间随机选择时间执行，
-避免固定时间被检测。支持跨天（如 22:00 ~ 02:00）。`;
+<b>🔄 时间范围说明：</b>
+设置 range 后，系统会每天在 time 到 range 之间随机选择一个时刻执行，
+这样可以避免每天都在同一时间签到。支持跨天，例如 22:00 到次日 02:00。`;
   }
 
   private async edit(msg: Api.Message, text: string): Promise<void> {


### PR DESCRIPTION
**定时执行时间段**
- 新增 runTimeEnd 配置，用于设置定时执行的结束时间。
- 插件会在 runTime 到 runTimeEnd 之间，每天随机选择一个时间执行签到。
- 支持跨天时间段，例如 22:00 到次日 02:00。
- 每天会在首次计算时生成当天的执行时间，之后当日内保持不变，避免反复变动。

**新增与优化的命令**
- 时间设置：[set time] [HH:MM] 用于设置开始时间；[set range] [HH:MM] 用于设置结束时间。
- 关闭随机时间段：直接使用 [set range]（不带参数），即可清除结束时间，恢复为固定时间执行。
- 短命令支持：set t (time), set r (range), set d (delay), set b (bot), set l (log)
- 命令别名：settings = config = info，set = config

**更新提示**
本次更新后，可能会默认在每天 10:00 到 11:30 之间随机执行签到。